### PR TITLE
[FEATURE] Add GitHub user namespace "typo3"

### DIFF
--- a/Classes/Changelog/GenerateChangelogIssue.php
+++ b/Classes/Changelog/GenerateChangelogIssue.php
@@ -66,7 +66,7 @@ class GenerateChangelogIssue
 
     public function __construct()
     {
-        $this->api = new GitHubApi('https://api.github.com/');
+        $this->api = new GitHubApi();
     }
 
     public function getBaseUrl(string $url): string

--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -3,7 +3,6 @@
 namespace T3docs\T3docsTools;
 
 use Symfony\Component\Yaml\Yaml;
-use Symfony\Component\Yaml\Exception\ParseException;
 
 class Configuration
 {
@@ -31,19 +30,9 @@ class Configuration
         return self::$instance;
     }
 
-    public function getConfiguration() : array
+    public function getIgnoredRepos(string $user): array
     {
-        return $this->config;
-    }
-
-    public function getRepositoriesUrl()
-    {
-        return $this->config['github']['cmd']['listRepos'];
-    }
-
-    public function getIgnoredRepos() : array
-    {
-        return $this->config['github']['repos']['ignore'] ?? [];
+        return $this->config['github']['repos'][$user]['ignore'] ?? [];
     }
 
 }

--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,11 @@
 t3doc-tools
 ===========
 
-Suite of tools, mostly for bulk changes in the TYPO3 documentation repositories
-and to output some statistics.
+Suite of tools, mostly for bulk changes in the repositories of the TYPO3 Documentation
+Team and the TYPO3 Core Team, and to output some statistics, where
 
-* part of this is written in PHP (focused on remote actions in GitHub)
-* some of them are bash scripts (focused on local actions in the cloned repositories)
+* part of this is written in PHP (focused on remote actions in GitHub) and
+* some of them are bash scripts (focused on local actions in the cloned repositories).
 
 Installation
 ============
@@ -22,9 +22,15 @@ Installation
 Configuration
 =============
 
-There are several repositories in https://github.com/TYPO3-Documentation.
+There are several repositories in
 
-Documentation repositories typically begin with "TYPO3CMS-".
+* https://github.com/TYPO3-Documentation and
+* https://github.com/TYPO3
+
+which are the home of the TYPO3 Documentation Team and the TYPO3 Core Team respectively.
+
+The names of the documentation manual repositories usually start with "TYPO3CMS-".
+These can be processed specifically.
 
 The config.yml file is used to filter out some repositories that are not yet
 archived but should not be maintained any longer.
@@ -32,6 +38,15 @@ archived but should not be maintained any longer.
 The bashScripts/config.sh file configures the local folder of the cloned repositories,
 which is generated-data/repos/ by default. The settings can be overridden with a custom
 bashScripts/config.local.sh file.
+
+The local repositories of each GitHub user namespace (currently "typo3-documentation" and "typo3")
+are cloned into local subfolders following the pattern generated-data/repos/<user>,
+i.e. currently into
+
+* generated-data/repos/typo3-documentation/ and
+* generated-data/repos/typo3/,
+
+– for separate and general processing.
 
 Usage: PHP
 ==========
@@ -41,36 +56,53 @@ The PHP scripts are located in the project root folder.
 get-repo-names.php
 ------------------
 
-Show list of currently relevant docs repos::
+List the remote repos::
 
-    php get-repo-names.php [<type>]
+    php get-repo-names.php [<type>] [<user>] [<token>]
 
-type can be:
+    Arguments:
+       type: Consider all repositories or only those starting with "TYPO3CMS-" (all, docs). [default: "docs"]
+       user: Consider the repositories of this GitHub user namespace (typo3-documentation, typo3), which has to be defined in the /config.yml. [default: "typo3-documentation"]
+       token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: ""]
 
-* 'docs' (default): all repositories that are documentation, i.e. the names begin with "TYPO3CMS-"
-* 'all': all repositories
+Example::
+
+    php get-repo-names.php docs typo3-documentation
 
 get-repo-branches.php
 ---------------------
 
-Show all branches for these repos::
+List the branches of the remote repos::
 
-    php get-repo-branches.php [<type>]
+    php get-repo-branches.php [<type>] [<user>] [<token>]
 
-type can be:
+    Arguments:
+       type: Consider all repositories or only those starting with "TYPO3CMS-" (all, docs). [default: "docs"]
+       user: Consider the repositories of this GitHub user namespace (typo3-documentation, typo3), which has to be defined in the /config.yml. [default: "typo3-documentation"]
+       token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: ""]
 
-* 'docs' (default): all repositories that are documentation, i.e. the names begin with "TYPO3CMS-"
-* 'all': all repositories
+Example::
+
+    php get-repo-branches.php all typo3
 
 get-contributors.php
 --------------------
 
-Fetch the list of contributors of the repos::
+List the contributors of the remote repos or a specific repo::
 
-    php get-contributors.php <year> [<GitHub token>]
+    php get-contributors.php [<year>] [<month>] [<type>] [<user>] [<repo>] [<token>]
 
-The GitHub token is necessary in order to make several requests to GitHub to get
-the commits of all repositories.
+    Arguments:
+       year: Consider commits of this year, "0" means the current year. [default: "0"]
+       month: Consider commits of this month, "0" means all months. [default: "0"]
+       type: Consider all repositories or only those starting with "TYPO3CMS-" (all, docs). [default: "docs"]
+       user: Consider the repositories of this GitHub user namespace (typo3-documentation, typo3), which has to be defined in the /config.yml. [default: "typo3-documentation"]
+       repo: Consider commits of this specific repository, "" means of all repositories. [default: ""]
+       token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: ""]
+
+Example::
+
+    php get-contributors.php 2021 8 all typo3-documentation t3docs-screenshots
 
 generate-changelog-issue.php
 ----------------------------
@@ -131,11 +163,16 @@ get-repos.sh
 Clones all TYPO3 documentation repositories (all) or only those starting with \"TYPO3CMS-\" (docs)
 from remote to local folder generated-data/repos/::
 
-    ./bashScripts/get-repos.sh [<type>]
+    ./bashScripts/get-repos.sh [<type>] [<user>] [<token>]
+
+    Arguments:
+       type: Fetch all repositories or only those starting with "TYPO3CMS-" (all, docs). [default: "all"]
+       user: Fetch the repositories of this GitHub user namespace (all, typo3-documentation, typo3), which has to be defined in the /config.yml. [default: "typo3-documentation"]
+       token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: ""]
 
 Example::
 
-    ./bashScripts/get-repos.sh docs
+    ./bashScripts/get-repos.sh docs typo3-documentation
 
 grep-for-settings.sh
 --------------------
@@ -143,11 +180,15 @@ grep-for-settings.sh
 This searches for a string in Documentation/Settings.cfg in all branches of those local repositories
 starting with \"TYPO3CMS-\" and stops on first hit::
 
-    ./bashScripts/grep-for-settings.sh <string>
+    ./bashScripts/grep-for-settings.sh <argument> [<user>]
+
+    Arguments:
+       argument: Search for this string in the Documentation/Settings.cfg files of the local repositories.
+       user: Search in the local repositories of this GitHub user namespace (all, typo3-documentation, typo3). [default: "typo3-documentation"]
 
 Example::
 
-    ./bashScripts/grep-for-settings.sh t3tssyntax
+    ./bashScripts/grep-for-settings.sh t3tssyntax typo3-documentation
 
 The repositories must already exist in generated-data/repos/. Call get-repos.sh to clone or update first.
 
@@ -156,11 +197,15 @@ search-repos.sh
 
 Execute a custom search command in all branches of all local repositories::
 
-    ./bashScripts/search-repos.sh <command>
+    ./bashScripts/search-repos.sh <command> [<user>]
+
+    Arguments:
+       command: Execute this search command in all branches of all local repositories.
+       user: Execute the search command in the local repositories of this GitHub user namespace (all, typo3-documentation, typo3). [default: "typo3-documentation"]
 
 Example::
 
-    ./bashScripts/search-repos.sh "grep -rnIE '\`https://typo3\.org' --exclude-dir='.git' ."
+    ./bashScripts/search-repos.sh "grep -rnIE '\`https://typo3\.org' --exclude-dir='.git' ." all
 
 The repositories must already exist in generated-data/repos/. Call get-repos.sh to clone or update first.
 
@@ -169,11 +214,15 @@ versionbranch-exist.sh
 
 Lists all local repositories for which a specific version branch exists::
 
-    ./bashScripts/versionbranch-exist.sh <version>
+    ./bashScripts/versionbranch-exist.sh <version> [<user>]
+
+    Arguments:
+       version: List all local repositories having a branch matching this version.
+       user: List local repositories of this GitHub user namespace (all, typo3-documentation, typo3). [default: "typo3-documentation"]
 
 Example::
 
-    ./bashScripts/versionbranch-exist.sh "7.6"
+    ./bashScripts/versionbranch-exist.sh "7.6" typo3
 
 The repositories must already exist in generated-data/repos/. Call get-repos.sh to clone or update first.
 
@@ -182,10 +231,14 @@ versionbranch-not-exist.sh
 
 Lists all local repositories for which a specific version branch does not exist::
 
-    ./bashScripts/versionbranch-not-exist.sh <version>
+    ./bashScripts/versionbranch-not-exist.sh <version> [<user>]
+
+    Arguments:
+       version: List all local repositories not having a branch matching this version.
+       user: List local repositories of this GitHub user namespace (all, typo3-documentation, typo3). [default: "typo3-documentation"]
 
 Example::
 
-    ./bashScripts/versionbranch-not-exist.sh "11.5"
+    ./bashScripts/versionbranch-not-exist.sh "11.5" typo3-documentation
 
 The repositories must already exist in generated-data/repos/. Call get-repos.sh to clone or update first.

--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,24 @@ Usage: bash scripts
 
 The bash scripts are located in subfolder bashScripts/.
 
+collect-stats.sh
+----------------
+
+Collect statistics on all branches of all local repositories. Currently supported is the display of the number of
+automatically generated screenshots::
+
+    ./bashScripts/collect-stats.sh [<type>] [<user>]
+
+    Arguments:
+       type: Collect the statistics of all repositories or only of those starting with "TYPO3CMS-" (all, docs). [default: "docs"]
+       user: Collect the statistics in the local repositories of this GitHub user namespace (all, typo3-documentation, typo3). [default: "typo3-documentation"]
+
+Example::
+
+    ./bashScripts/collect-stats.sh all typo3
+
+The repositories must already exist in generated-data/repos/. Call get-repos.sh to clone or update first.
+
 get-repos.sh
 ------------
 

--- a/bashScripts/collect-stats.sh
+++ b/bashScripts/collect-stats.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# -------------------
+# automatic variables
+# -------------------
+thisdir=$(dirname $0)
+cd $thisdir
+thisdir=$(pwd)
+
+# config
+source $thisdir/config.sh
+
+function usage()
+{
+    echo "Usage: $0 [<type>] [<user>]"
+    echo ""
+    echo "Arguments:"
+    echo "   type: Collect the statistics of all repositories or only of those starting with \"TYPO3CMS-\" (all, docs). [default: \"docs\"]"
+    echo "   user: Collect the statistics in the local repositories of this GitHub user namespace (all, typo3-documentation, typo3). [default: \"typo3-documentation\"]"
+    exit 1
+}
+
+function exitMsg()
+{
+    echo "ERROR: $*"
+    exit 1
+}
+
+if [ $# -gt 2 ]; then
+    usage
+fi
+
+type="${1:-docs}"
+user="${2:-typo3-documentation}"
+if [ "$user" = "all" ]; then
+    users="typo3-documentation typo3"
+elif [ "$user" = "typo3-documentation" ] || [ "$user" = "typo3" ]; then
+    users="$user"
+else
+    usage
+fi
+
+declare -A screenshots
+
+for user in $users; do
+    userdir="$repodir/$user"
+
+    if [ ! -d "$userdir" ]; then
+        exitMsg "The TYPO3 repositories are not pulled to \"$userdir\" yet. Run get-repos.sh first."
+    fi
+
+    echo "------------------------------------------------------------------------"
+    echo "Collect stats command in local repositories of type \"$type\" of "
+    echo "$userdir/."
+    echo "------------------------------------------------------------------------"
+
+    cd "$userdir"
+    for repo in *; do
+        if [ ! -d "$userdir/$repo" ]; then
+            break;
+        fi
+        if [ "$type" = "docs" ] && [[ ! $repo =~ ^TYPO3CMS\- ]]; then
+            continue;
+        fi
+        latestbranch=""
+        cd "$userdir/$repo"
+        for branch in master main 11.5 10.4 9.5 8.7 7.6; do
+            # Checkout and update current branch
+            exists=$(git branch -a --list "$branch" --list "origin/$branch")
+            if [ -n "$exists" ]; then
+                git checkout $branch || exitMsg "checkout $branch in $repo"
+                git reset --hard origin/$branch || exitMsg "reset --hard origin/$branch in $repo"
+            else
+                continue
+            fi
+            if [ -z "$latestbranch" ]; then
+                latestbranch="$branch"
+            fi
+
+            # Collect automatic screenshots statistics
+            if echo "master main 11.5" | grep -w "$branch"; then
+                documentationFolders=$(find . -type d -name "Documentation")
+                for documentationFolder in $documentationFolders; do
+                    numImages=$(find "$documentationFolder" -type f \( -iname "*.png" -or -iname "*.jpg" -or -iname "*.jpeg" -or -iname "*.gif" -or -iname "*.webp" \) | wc -l)
+                    numAutomatic=0
+                    automaticFolders=$(find "$documentationFolder" -type d -name "AutomaticScreenshots")
+                    for automaticFolder in $automaticFolders; do
+                        n=$(find "$automaticFolder" -type f \( -iname "*.png" -or -iname "*.jpg" -or -iname "*.jpeg" -or -iname "*.gif" -or -iname "*.webp" \) | wc -l)
+                        numAutomatic=$((numAutomatic+n))
+                    done
+                    screenshots["$user/$repo/$branch:$documentationFolder|all"]=$numImages
+                    screenshots["$user/$repo/$branch:$documentationFolder|automatic"]=$numAutomatic
+                done
+            fi
+        done
+        if [ -n "$latestbranch" ]; then
+            git checkout $latestbranch
+        fi
+    done
+done
+
+echo "------------------------------------------------------------------------"
+echo "Automatic screenshots"
+echo "------------------------------------------------------------------------"
+totalImages=0
+totalAutomatic=0
+# Sort statistics by repository name
+mapfile -d '' sorted < <(printf '%s\0' "${!screenshots[@]}" | sort -z)
+# Print statistics
+for x in "${sorted[@]}"; do
+    if [[ $x =~ \|all$ ]]; then
+        documentationPath=${x%|*}
+        numImages=${screenshots["$documentationPath|all"]}
+        numAutomatic=${screenshots["$documentationPath|automatic"]}
+        if [ "$numImages" -gt 0 ]; then
+            totalImages=$((totalImages+numImages))
+            totalAutomatic=$((totalAutomatic+numAutomatic))
+            percentage=$(echo "result=$numAutomatic/$numImages*100;scale=2;result/1" | bc -l)
+            printf "[%s] = %s (automatic) / %s (all) = %s%%\n" "$documentationPath" "$numAutomatic" "$numImages" "$percentage"
+        fi
+    fi
+done
+totalPercentage=0
+if [ "$totalImages" -gt 0 ]; then
+    totalPercentage=$(echo "result=$totalAutomatic/$totalImages*100;scale=2;result/1" | bc -l)
+fi
+echo "------------------------------------------------------------------------"
+printf "Total = %s (automatic) / %s (all) = %s%%\n" "$totalAutomatic" "$totalImages" "$totalPercentage"
+echo "------------------------------------------------------------------------"

--- a/bashScripts/get-repos.sh
+++ b/bashScripts/get-repos.sh
@@ -12,10 +12,12 @@ source $thisdir/config.sh
 
 function usage()
 {
-    echo "Usage: $0 [<type>]"
+    echo "Usage: $0 [<type>] [<user>] [<token>]"
     echo ""
     echo "Arguments:"
     echo "   type: Fetch all repositories or only those starting with \"TYPO3CMS-\" (all, docs). [default: \"all\"]"
+    echo "   user: Fetch the repositories of this GitHub user namespace (all, typo3-documentation, typo3), which has to be defined in the /config.yml. [default: \"typo3-documentation\"]"
+    echo "   token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: \"\"]"
     exit 1
 }
 
@@ -25,44 +27,61 @@ function exitMsg()
     exit 1
 }
 
-type="${1:-all}"
-if [ "$type" != "all" ] && [ "$type" != "docs" ]; then
+if [ $# -gt 3 ]; then
     usage
 fi
 
-if ! mkdir -p "$repodir"; then
-    exitMsg "Error creating directory \"$repodir\"."
+type="${1:-all}"
+user="${2:-typo3-documentation}"
+token="${3:-}"
+if [ "$type" != "all" ] && [ "$type" != "docs" ]; then
+    usage
+fi
+if [ "$user" = "all" ]; then
+    users="typo3-documentation typo3"
+elif [ "$user" = "typo3-documentation" ] || [ "$user" = "typo3" ]; then
+    users="$user"
+else
+    usage
 fi
 
-echo "Clone or update local repositories of"
-echo "$repodir/."
-echo "------------------------------------------------------------------------"
+for user in $users; do
+    userdir="$repodir/$user"
 
-php -f $phpdir/get-repo-names.php $type | while read repo; do
-    cd "$repodir"
-    if [ ! -d "$repo" ]; then
-        echo "Cloning repo $repo."
-        git clone git@github.com:TYPO3-Documentation/$repo.git || exitMsg "clone $repo"
-    else
-        echo "$repo already exists: Update remote tracking branches, checkout and update main branch."
-        cd "$repo"
-        # Update remote tracking branches
-        git fetch || exitMsg "fetch $repo"
-        # Checkout and update main branch
-        mainbranch=""
-        for branch in master main; do
-            exists=$(git branch -a --list "$branch" --list "origin/$branch")
-            if [ -n "$exists" ]; then
-                mainbranch="$branch"
-                break
-            fi
-        done
-        if [ -n "$mainbranch" ]; then
-            git checkout $mainbranch || exitMsg "checkout $mainbranch in $repo"
-            git reset --hard origin/$mainbranch || exitMsg "reset --hard origin/$mainbranch in $repo"
-        else
-            echo "The $repo repo is not yet initialized because it lacks a main branch."
-        fi
+    if ! mkdir -p "$userdir"; then
+        exitMsg "Error creating directory \"$userdir\"."
     fi
+
+    echo "Clone or update local repositories of"
+    echo "$userdir/."
     echo "------------------------------------------------------------------------"
+
+    php -f $phpdir/get-repo-names.php "$type" "$user" "$token" | while read repo; do
+        cd "$userdir"
+        if [ ! -d "$repo" ]; then
+            echo "Cloning repo $repo."
+            git clone "git@github.com:$user/$repo.git" || exitMsg "clone $repo"
+        else
+            echo "$repo already exists: Update remote tracking branches, checkout and update main branch."
+            cd "$repo"
+            # Update remote tracking branches
+            git fetch || exitMsg "fetch $repo"
+            # Checkout and update main branch
+            mainbranch=""
+            for branch in master main; do
+                exists=$(git branch -a --list "$branch" --list "origin/$branch")
+                if [ -n "$exists" ]; then
+                    mainbranch="$branch"
+                    break
+                fi
+            done
+            if [ -n "$mainbranch" ]; then
+                git checkout $mainbranch || exitMsg "checkout $mainbranch in $repo"
+                git reset --hard origin/$mainbranch || exitMsg "reset --hard origin/$mainbranch in $repo"
+            else
+                echo "The $repo repo is not yet initialized because it lacks a main branch."
+            fi
+        fi
+        echo "------------------------------------------------------------------------"
+    done
 done

--- a/bashScripts/search-repos.sh
+++ b/bashScripts/search-repos.sh
@@ -12,10 +12,11 @@ source $thisdir/config.sh
 
 function usage()
 {
-    echo "Usage: $0 <command>"
+    echo "Usage: $0 <command> [<user>]"
     echo ""
     echo "Arguments:"
     echo "   command: Execute this search command in all branches of all local repositories."
+    echo "   user: Execute the search command in the local repositories of this GitHub user namespace (all, typo3-documentation, typo3). [default: \"typo3-documentation\"]"
     exit 1
 }
 
@@ -25,66 +26,82 @@ function exitMsg()
     exit 1
 }
 
-if [ $# -ne 1 ]; then
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
     usage
 fi
 
-if [ ! -d "$repodir" ]; then
-    exitMsg "The TYPO3 documentation repositories are not pulled to \"$repodir\" yet. Run get-repos.sh first."
-fi
-
 cmd="$1"
+user="${2:-typo3-documentation}"
+if [ "$user" = "all" ]; then
+    users="typo3-documentation typo3"
+elif [ "$user" = "typo3-documentation" ] || [ "$user" = "typo3" ]; then
+    users="$user"
+else
+    usage
+fi
 
 quiet=0
 stopOnFirstHit=0
 
-echo "Run search command "
-echo "-"
-echo "$cmd"
-echo "-"
-echo "in local repositories of "
-echo "$repodir/."
-echo "------------------------------------------------------------------------"
+for user in $users; do
+    userdir="$repodir/$user"
 
-cd "$repodir"
-for repo in *; do
-    latestbranch=""
-    cd "$repodir/$repo"
-    for branch in master main 11.5 10.4 9.5 8.7 7.6; do
-        # Checkout and update current branch
-        exists=$(git branch -a --list "$branch" --list "origin/$branch")
-        if [ -n "$exists" ]; then
-            git checkout $branch || exitMsg "checkout $branch in $repo"
-            git reset --hard origin/$branch || exitMsg "reset --hard origin/$branch in $repo"
-        else
-            continue
+    if [ ! -d "$userdir" ]; then
+        exitMsg "The TYPO3 repositories are not pulled to \"$userdir\" yet. Run get-repos.sh first."
+    fi
+
+    echo "------------------------------------------------------------------------"
+    echo "Run search command "
+    echo "-"
+    echo "$cmd"
+    echo "-"
+    echo "in local repositories of "
+    echo "$userdir/."
+    echo "------------------------------------------------------------------------"
+
+    cd "$userdir"
+    for repo in *; do
+        if [ ! -d "$userdir/$repo" ]; then
+            break;
         fi
-        if [ -z "$latestbranch" ]; then
-            latestbranch="$branch"
-        fi
-        # Search
-        result=$(eval "$cmd")
-        resultNum=$(echo "$result" | wc -l)
-        if [ -n "$result" ] ; then
-            echo "------------------------------------------------------------------------"
-            echo "$repo ($branch): $resultNum search results."
-            if [ $quiet -ne 1 ] ; then
+        latestbranch=""
+        cd "$userdir/$repo"
+        for branch in master main 11.5 10.4 9.5 8.7 7.6; do
+            # Checkout and update current branch
+            exists=$(git branch -a --list "$branch" --list "origin/$branch")
+            if [ -n "$exists" ]; then
+                git checkout $branch || exitMsg "checkout $branch in $repo"
+                git reset --hard origin/$branch || exitMsg "reset --hard origin/$branch in $repo"
+            else
+                continue
+            fi
+            if [ -z "$latestbranch" ]; then
+                latestbranch="$branch"
+            fi
+            # Search
+            result=$(eval "$cmd")
+            resultNum=$(echo "$result" | wc -l)
+            if [ -n "$result" ] ; then
                 echo "------------------------------------------------------------------------"
-                echo "$result"
-            fi
-            echo "------------------------------------------------------------------------"
-            if [ $stopOnFirstHit -eq 1 ]; then
-                echo "Stopping on first hit."
-                if [ -n "$latestbranch" ]; then
-                    git checkout $latestbranch
+                echo "$repo ($branch): $resultNum search results."
+                if [ $quiet -ne 1 ] ; then
+                    echo "------------------------------------------------------------------------"
+                    echo "$result"
                 fi
-                exit 0
+                echo "------------------------------------------------------------------------"
+                if [ $stopOnFirstHit -eq 1 ]; then
+                    echo "Stopping on first hit."
+                    if [ -n "$latestbranch" ]; then
+                        git checkout $latestbranch
+                    fi
+                    exit 0
+                fi
+            else
+                echo "$repo ($branch): No search results."
             fi
-        else
-            echo "$repo ($branch): No search results."
+        done
+        if [ -n "$latestbranch" ]; then
+            git checkout $latestbranch
         fi
     done
-    if [ -n "$latestbranch" ]; then
-        git checkout $latestbranch
-    fi
 done

--- a/bashScripts/versionbranch-exist.sh
+++ b/bashScripts/versionbranch-exist.sh
@@ -12,10 +12,11 @@ source $thisdir/config.sh
 
 function usage()
 {
-    echo "Usage: $0 <version>"
+    echo "Usage: $0 <version> [<user>]"
     echo ""
     echo "Arguments:"
     echo "   version: List all local repositories having a branch matching this version."
+    echo "   user: List local repositories of this GitHub user namespace (all, typo3-documentation, typo3). [default: \"typo3-documentation\"]"
     exit 1
 }
 
@@ -25,22 +26,38 @@ function exitMsg()
     exit 1
 }
 
-if [ $# -ne 1 ]; then
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
     usage
 fi
 
-if [ ! -d "$repodir" ]; then
-    exitMsg "The TYPO3 documentation repositories are not pulled to \"$repodir\" yet. Run get-repos.sh first."
+version=$1
+user="${2:-typo3-documentation}"
+if [ "$user" = "all" ]; then
+    users="typo3-documentation typo3"
+elif [ "$user" = "typo3-documentation" ] || [ "$user" = "typo3" ]; then
+    users="$user"
+else
+    usage
 fi
 
-version=$1
+for user in $users; do
+    userdir="$repodir/$user"
 
-cd "$repodir"
-for repo in TYPO3CMS*; do
-    cd "$repodir/$repo"
-
-    git branch -a | grep "remotes\/origin\/$version" >/dev/null
-    if [ $? -eq 0 ]; then
-        echo "$repo has version $version."
+    if [ ! -d "$userdir" ]; then
+        exitMsg "The TYPO3 repositories are not pulled to \"$userdir\" yet. Run get-repos.sh first."
     fi
+
+    cd "$userdir"
+    for repo in *; do
+        if [ ! -d "$userdir/$repo" ]; then
+            break;
+        fi
+
+        cd "$userdir/$repo"
+
+        git branch -a | grep "remotes\/origin\/$version" >/dev/null
+        if [ $? -eq 0 ]; then
+            echo "$repo has version $version."
+        fi
+    done
 done

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     }
   },
   "require": {
+    "ext-json": "*",
     "guzzlehttp/guzzle": "^6.3.0",
     "symfony/yaml": "^4.1",
     "symfony/dom-crawler": "^4.3",

--- a/config.yml
+++ b/config.yml
@@ -8,9 +8,12 @@ general:
 github:
   cmd:
     baseURl:  https://api.github.com/
-    listRepos: /users/TYPO3-Documentation/repos?per_page=100
   repos:
-    ignore:
-      - TYPO3CMS-Reference-FileAbstractionLayer
-      - TYPO3CMS-Tutorial-CreatingExtensions
-      - TYPO3CMS-Guide-Extbase
+    typo3-documentation:
+      ignore:
+        - TYPO3CMS-Reference-FileAbstractionLayer
+        - TYPO3CMS-Tutorial-CreatingExtensions
+        - TYPO3CMS-Guide-Extbase
+    typo3:
+      ignore:
+#        - .github

--- a/get-contributors.php
+++ b/get-contributors.php
@@ -1,43 +1,41 @@
 <?php
-/**
- * - use private config for token
- * - use config for: year, etc.
- */
 
-use T3docs\T3docsTools\Configuration;
 use T3docs\T3docsTools\GitHub\GithubRepository;
 
 $loader = require 'vendor/autoload.php';
 
 function usage()
 {
-    print("Usage: get-contributors.php <year> [token]\n");
+    print("Usage: php get-contributors.php [<year>] [<month>] [<type>] [<user>] [<repo>] [<token>]\n");
+    print("\n");
+    print("Arguments:\n");
+    print("   year: Consider commits of this year, \"0\" means the current year. [default: \"0\"]\n");
+    print("   month: Consider commits of this month, \"0\" means all months. [default: \"0\"]\n");
+    print("   type: Consider all repositories or only those starting with \"TYPO3CMS-\" (all, docs). [default: \"docs\"]\n");
+    print("   user: Consider the repositories of this GitHub user namespace (typo3-documentation, typo3), which has to be defined in the /config.yml. [default: \"typo3-documentation\"]\n");
+    print("   repo: Consider commits of this specific repository, \"\" means of all repositories. [default: \"\"]\n");
+    print("   token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: \"\"]\n");
     exit(1);
 }
 
-if ($argv[1] ?? false) {
-    $year = $argv[1];
-} else {
+if ($argc > 7) {
     usage();
 }
 
-$token = null;
-if ($argv[2] ?? false) {
-    $token = $argv[2];
-}
+$year = $argv[1] ?? 0;
+$month = $argv[2] ?? 0;
+$type = $argv[3] ?? 'docs';
+$user = $argv[4] ?? 'typo3-documentation';
+$repo = $argv[5] ?? '';
+$token = $argv[6] ?? '';
 
-$config = Configuration::getInstance()->getConfiguration();
+$gitRepository = new GithubRepository($token);
+$gitRepository->fetchRepos($user, $type);
+$contributors = $gitRepository->fetchContributors($repo, $year, $month);
 
-$gitRepository = new GithubRepository('all', $token);
-
-$names = $gitRepository->getNames();
-
-$contributors = $gitRepository->getContributors( $year);
-
-$filename = 'contributors-' . $year . '.csv';
-
+$year = $year == 0 ? intval(date("Y")) : $year;
+$filename = $month == 0 ? 'contributors-' . $year . '.csv' : 'contributors-' . $year . '_' . $month . '.csv';
 $file = fopen($filename, 'w');
-
 fwrite($file,"count,name,email,id\n");
 foreach($contributors as $id => $contributor) {
     $line = $contributor['count'] . ',' . $contributor['name'] . ',' . $contributor['email'] . ',' . $id;
@@ -45,7 +43,6 @@ foreach($contributors as $id => $contributor) {
 }
 fclose($file);
 
-print("\n\n");
 print("----------------------\n");
 print("------- Results ------\n");
 print("----------------------\n\n");

--- a/get-repo-branches.php
+++ b/get-repo-branches.php
@@ -1,23 +1,36 @@
 <?php
 
-use T3docs\T3docsTools\Configuration;
 use T3docs\T3docsTools\GitHub\GithubRepository;
 
 $loader = require 'vendor/autoload.php';
 
-$config = Configuration::getInstance()->getConfiguration();
-
-$type = 'docs';
-if ($argv[1] ?? false) {
-    $type = $argv[1];
+function usage()
+{
+    print("Usage: php get-repo-branches.php [<type>] [<user>] [<token>]\n");
+    print("\n");
+    print("Arguments:\n");
+    print("   type: Consider all repositories or only those starting with \"TYPO3CMS-\" (all, docs). [default: \"docs\"]\n");
+    print("   user: Consider the repositories of this GitHub user namespace (typo3-documentation, typo3), which has to be defined in the /config.yml. [default: \"typo3-documentation\"]\n");
+    print("   token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: \"\"]\n");
+    exit(1);
 }
 
-$gitRepository = new GithubRepository($type);
-$names = $gitRepository->getNames();
-foreach($names as $name) {
-    print("$name\n");
+if ($argc > 4) {
+    usage();
+}
 
-    $branches = $gitRepository->getBranchInfosForRepoName($name);
+$type = $argv[1] ?? 'docs';
+$user = $argv[2] ?? 'typo3-documentation';
+$token = $argv[3] ?? '';
+
+$gitRepository = new GithubRepository($token);
+$gitRepository->fetchRepos($user, $type);
+$repos = $gitRepository->getNames();
+
+foreach($repos as $repo) {
+    print("$repo\n");
+
+    $branches = $gitRepository->fetchBranchNamesOfRepo($user, $repo);
     foreach ($branches as $branch) {
         print("  $branch \n");
     }

--- a/get-repo-names.php
+++ b/get-repo-names.php
@@ -1,20 +1,32 @@
 <?php
 
-use T3docs\T3docsTools\Configuration;
 use T3docs\T3docsTools\GitHub\GithubRepository;
 
 $loader = require 'vendor/autoload.php';
 
-$config = Configuration::getInstance()->getConfiguration();
-
-$type = 'docs';
-if ($argv[1] ?? false) {
-    $type = $argv[1];
+function usage()
+{
+    print("Usage: php get-repo-names.php [<type>] [<user>] [<token>]\n");
+    print("\n");
+    print("Arguments:\n");
+    print("   type: Consider all repositories or only those starting with \"TYPO3CMS-\" (all, docs). [default: \"docs\"]\n");
+    print("   user: Consider the repositories of this GitHub user namespace (typo3-documentation, typo3), which has to be defined in the /config.yml. [default: \"typo3-documentation\"]\n");
+    print("   token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: \"\"]\n");
+    exit(1);
 }
 
-$gitRepository = new GithubRepository($type);
-$names = $gitRepository->getNames();
+if ($argc > 4) {
+    usage();
+}
 
-foreach($names as $name) {
-    print("$name\n");
+$type = $argv[1] ?? 'docs';
+$user = $argv[2] ?? 'typo3-documentation';
+$token = $argv[3] ?? '';
+
+$gitRepository = new GithubRepository($token);
+$gitRepository->fetchRepos($user, $type);
+$repos = $gitRepository->getNames();
+
+foreach($repos as $repo) {
+    print("$repo\n");
 }


### PR DESCRIPTION
In addition to the GitHub namespace "typo3-documentation", where most of the official TYPO3 documentation and tools of the TYPO3 Documentation Team are located, with this patch also the repositories of the TYPO3 Core Team in the namespace "TYPO3" can be accessed and searched.

The PHP files have been streamlined.

---

Best to test:

(1)
```
./bashScripts/get-repos.sh all all
```
=> check that there are two folders `/generated-data/repos/typo3/` and `/generated-data/repos/typo3-documentation/` containing all repositories of TYPO3-Documentation and TYPO3 GitHub user namespace.

(2)
```
./bashScripts/search-repos.sh "grep -rnIE '[Ll]icense' --exclude-dir='.git' --include='composer.json' --include='Index.rst'  ." all
```
=> check output for search results of "license" in `composer.json` and `Index.rst` files in all relevant branches of all repositories of TYPO3-Documentation and TYPO3 GitHub user namespaces.