### PR TITLE
[FEATURE] Show automatic screenshots stats with `collect-stats.sh`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,24 @@ Usage: bash scripts
 
 The bash scripts are located in subfolder bashScripts/.
 
+collect-stats.sh
+----------------
+
+Collect statistics on all branches of all local repositories. Currently supported is the display of the number of
+automatically generated screenshots::
+
+    ./bashScripts/collect-stats.sh [<type>] [<user>]
+
+    Arguments:
+       type: Collect the statistics of all repositories or only of those starting with "TYPO3CMS-" (all, docs). [default: "docs"]
+       user: Collect the statistics in the local repositories of this GitHub user namespace (all, typo3-documentation, typo3). [default: "typo3-documentation"]
+
+Example::
+
+    ./bashScripts/collect-stats.sh all typo3
+
+The repositories must already exist in generated-data/repos/. Call get-repos.sh to clone or update first.
+
 get-repos.sh
 ------------
 

--- a/bashScripts/collect-stats.sh
+++ b/bashScripts/collect-stats.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# -------------------
+# automatic variables
+# -------------------
+thisdir=$(dirname $0)
+cd $thisdir
+thisdir=$(pwd)
+
+# config
+source $thisdir/config.sh
+
+function usage()
+{
+    echo "Usage: $0 [<type>] [<user>]"
+    echo ""
+    echo "Arguments:"
+    echo "   type: Collect the statistics of all repositories or only of those starting with \"TYPO3CMS-\" (all, docs). [default: \"docs\"]"
+    echo "   user: Collect the statistics in the local repositories of this GitHub user namespace (all, typo3-documentation, typo3). [default: \"typo3-documentation\"]"
+    exit 1
+}
+
+function exitMsg()
+{
+    echo "ERROR: $*"
+    exit 1
+}
+
+if [ $# -gt 2 ]; then
+    usage
+fi
+
+type="${1:-docs}"
+user="${2:-typo3-documentation}"
+if [ "$user" = "all" ]; then
+    users="typo3-documentation typo3"
+elif [ "$user" = "typo3-documentation" ] || [ "$user" = "typo3" ]; then
+    users="$user"
+else
+    usage
+fi
+
+declare -A screenshots
+
+for user in $users; do
+    userdir="$repodir/$user"
+
+    if [ ! -d "$userdir" ]; then
+        exitMsg "The TYPO3 repositories are not pulled to \"$userdir\" yet. Run get-repos.sh first."
+    fi
+
+    echo "------------------------------------------------------------------------"
+    echo "Collect stats command in local repositories of type \"$type\" of "
+    echo "$userdir/."
+    echo "------------------------------------------------------------------------"
+
+    cd "$userdir"
+    for repo in *; do
+        if [ ! -d "$userdir/$repo" ]; then
+            break;
+        fi
+        if [ "$type" = "docs" ] && [[ ! $repo =~ ^TYPO3CMS\- ]]; then
+            continue;
+        fi
+        latestbranch=""
+        cd "$userdir/$repo"
+        for branch in master main 11.5 10.4 9.5 8.7 7.6; do
+            # Checkout and update current branch
+            exists=$(git branch -a --list "$branch" --list "origin/$branch")
+            if [ -n "$exists" ]; then
+                git checkout $branch || exitMsg "checkout $branch in $repo"
+                git reset --hard origin/$branch || exitMsg "reset --hard origin/$branch in $repo"
+            else
+                continue
+            fi
+            if [ -z "$latestbranch" ]; then
+                latestbranch="$branch"
+            fi
+
+            # Collect automatic screenshots statistics
+            if echo "master main 11.5" | grep -w "$branch"; then
+                documentationFolders=$(find . -type d -name "Documentation")
+                for documentationFolder in $documentationFolders; do
+                    numImages=$(find "$documentationFolder" -type f \( -iname "*.png" -or -iname "*.jpg" -or -iname "*.jpeg" -or -iname "*.gif" -or -iname "*.webp" \) | wc -l)
+                    numAutomatic=0
+                    automaticFolders=$(find "$documentationFolder" -type d -name "AutomaticScreenshots")
+                    for automaticFolder in $automaticFolders; do
+                        n=$(find "$automaticFolder" -type f \( -iname "*.png" -or -iname "*.jpg" -or -iname "*.jpeg" -or -iname "*.gif" -or -iname "*.webp" \) | wc -l)
+                        numAutomatic=$((numAutomatic+n))
+                    done
+                    screenshots["$user/$repo/$branch:$documentationFolder|all"]=$numImages
+                    screenshots["$user/$repo/$branch:$documentationFolder|automatic"]=$numAutomatic
+                done
+            fi
+        done
+        if [ -n "$latestbranch" ]; then
+            git checkout $latestbranch
+        fi
+    done
+done
+
+echo "------------------------------------------------------------------------"
+echo "Automatic screenshots"
+echo "------------------------------------------------------------------------"
+totalImages=0
+totalAutomatic=0
+# Sort statistics by repository name
+mapfile -d '' sorted < <(printf '%s\0' "${!screenshots[@]}" | sort -z)
+# Print statistics
+for x in "${sorted[@]}"; do
+    if [[ $x =~ \|all$ ]]; then
+        documentationPath=${x%|*}
+        numImages=${screenshots["$documentationPath|all"]}
+        numAutomatic=${screenshots["$documentationPath|automatic"]}
+        if [ "$numImages" -gt 0 ]; then
+            totalImages=$((totalImages+numImages))
+            totalAutomatic=$((totalAutomatic+numAutomatic))
+            percentage=$(echo "result=$numAutomatic/$numImages*100;scale=2;result/1" | bc -l)
+            printf "[%s] = %s (automatic) / %s (all) = %s%%\n" "$documentationPath" "$numAutomatic" "$numImages" "$percentage"
+        fi
+    fi
+done
+totalPercentage=0
+if [ "$totalImages" -gt 0 ]; then
+    totalPercentage=$(echo "result=$totalAutomatic/$totalImages*100;scale=2;result/1" | bc -l)
+fi
+echo "------------------------------------------------------------------------"
+printf "Total = %s (automatic) / %s (all) = %s%%\n" "$totalAutomatic" "$totalImages" "$totalPercentage"
+echo "------------------------------------------------------------------------"


### PR DESCRIPTION
Collect statistics on all branches of all local repositories. Currently supported is the display of the number of automatically generated screenshots.

Test with:
```
./bashScripts/collect-stats.sh
```
and confirm that it displays:
```
------------------------------------------------------------------------
Automatic screenshots
------------------------------------------------------------------------
[typo3-documentation/TYPO3CMS-Book-ExtbaseFluid/11.5:./Documentation] = 0 (automatic) / 47 (all) = 0%
[typo3-documentation/TYPO3CMS-Book-ExtbaseFluid/main:./Documentation] = 0 (automatic) / 47 (all) = 0%
[typo3-documentation/TYPO3CMS-CheatSheets/main:./Documentation] = 0 (automatic) / 2 (all) = 0%
[typo3-documentation/TYPO3CMS-Example-ExtensionManual/main:./Documentation] = 0 (automatic) / 3 (all) = 0%
[typo3-documentation/TYPO3CMS-Exceptions/main:./Documentation] = 0 (automatic) / 10 (all) = 0%
[typo3-documentation/TYPO3CMS-Guide-ContributionWorkflow/main:./Documentation] = 0 (automatic) / 88 (all) = 0%
[typo3-documentation/TYPO3CMS-Guide-FrontendLocalization/11.5:./Documentation] = 0 (automatic) / 29 (all) = 0%
[typo3-documentation/TYPO3CMS-Guide-FrontendLocalization/main:./Documentation] = 0 (automatic) / 30 (all) = 0%
[typo3-documentation/TYPO3CMS-Guide-HowToDocument/main:./Documentation] = 0 (automatic) / 61 (all) = 0%
[typo3-documentation/TYPO3CMS-Guide-Installation/11.5:./Documentation] = 17 (automatic) / 28 (all) = 60.71%
[typo3-documentation/TYPO3CMS-Guide-Installation/main:./Documentation] = 17 (automatic) / 28 (all) = 60.71%
[typo3-documentation/TYPO3CMS-Reference-CoreApi/11.5:./Documentation] = 97 (automatic) / 140 (all) = 69.28%
[typo3-documentation/TYPO3CMS-Reference-CoreApi/main:./Documentation] = 97 (automatic) / 137 (all) = 70.80%
[typo3-documentation/TYPO3CMS-Reference-Skinning/main:./Documentation] = 0 (automatic) / 4 (all) = 0%
[typo3-documentation/TYPO3CMS-Reference-TCA/11.5:./Documentation] = 119 (automatic) / 159 (all) = 74.84%
[typo3-documentation/TYPO3CMS-Reference-TCA/main:./Documentation] = 119 (automatic) / 159 (all) = 74.84%
[typo3-documentation/TYPO3CMS-Reference-TSconfig/11.5:./Documentation] = 4 (automatic) / 41 (all) = 9.75%
[typo3-documentation/TYPO3CMS-Reference-TSconfig/main:./Documentation] = 4 (automatic) / 41 (all) = 9.75%
[typo3-documentation/TYPO3CMS-Reference-Typoscript/11.5:./Documentation] = 13 (automatic) / 40 (all) = 32.50%
[typo3-documentation/TYPO3CMS-Reference-Typoscript/main:./Documentation] = 13 (automatic) / 40 (all) = 32.50%
[typo3-documentation/TYPO3CMS-Tutorial-Editors/11.5:./Documentation] = 68 (automatic) / 105 (all) = 64.76%
[typo3-documentation/TYPO3CMS-Tutorial-Editors/main:./Documentation] = 68 (automatic) / 105 (all) = 64.76%
[typo3-documentation/TYPO3CMS-Tutorial-GettingStarted/11.5:./Documentation] = 27 (automatic) / 68 (all) = 39.70%
[typo3-documentation/TYPO3CMS-Tutorial-GettingStarted/main:./Documentation] = 27 (automatic) / 68 (all) = 39.70%
[typo3-documentation/TYPO3CMS-Tutorial-SitePackage/11.5:./Documentation] = 19 (automatic) / 21 (all) = 90.47%
[typo3-documentation/TYPO3CMS-Tutorial-SitePackage/main:./Documentation] = 19 (automatic) / 21 (all) = 90.47%
[typo3-documentation/TYPO3CMS-Tutorial-Typoscript45Minutes/11.5:./Documentation] = 2 (automatic) / 5 (all) = 40.00%
[typo3-documentation/TYPO3CMS-Tutorial-Typoscript45Minutes/main:./Documentation] = 2 (automatic) / 5 (all) = 40.00%
------------------------------------------------------------------------
Total = 732 (automatic) / 1532 (all) = 47.78%
------------------------------------------------------------------------
```