### PR TITLE
[TASK] Search also branches 11, 10, 9, 8, 7

### DIFF
--- a/bashScripts/collect-stats.sh
+++ b/bashScripts/collect-stats.sh
@@ -64,7 +64,7 @@ for user in $users; do
         fi
         latestbranch=""
         cd "$userdir/$repo"
-        for branch in master main 11.5 11.x 10.4 10.x 9.5 9.x 8.7 8.x 7.6 7.x; do
+        for branch in master main 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
             # Checkout and update current branch
             exists=$(git branch -a --list "$branch" --list "origin/$branch")
             if [ -n "$exists" ]; then
@@ -78,7 +78,7 @@ for user in $users; do
             fi
 
             # Collect automatic screenshots statistics
-            if echo "master main 11.5 11.x" | grep -w "$branch"; then
+            if echo "master main 11.5 11.x 11" | grep -w "$branch"; then
                 documentationFolders=$(find . -type d -name "Documentation")
                 for documentationFolder in $documentationFolders; do
                     numImages=$(find "$documentationFolder" -type f \( -iname "*.png" -or -iname "*.jpg" -or -iname "*.jpeg" -or -iname "*.gif" -or -iname "*.webp" \) | wc -l)

--- a/bashScripts/grep-for-settings.sh
+++ b/bashScripts/grep-for-settings.sh
@@ -66,7 +66,7 @@ for user in $users; do
         fi
         latestbranch=""
         cd "$userdir/$repo"
-        for branch in master main 11.5 11.x 10.4 10.x 9.5 9.x 8.7 8.x 7.6 7.x; do
+        for branch in master main 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
             # Checkout and update current branch
             exists=$(git branch -a --list "$branch" --list "origin/$branch")
             if [ -n "$exists" ]; then

--- a/bashScripts/search-repos.sh
+++ b/bashScripts/search-repos.sh
@@ -68,7 +68,7 @@ for user in $users; do
         fi
         latestbranch=""
         cd "$userdir/$repo"
-        for branch in master main 11.5 11.x 10.4 10.x 9.5 9.x 8.7 8.x 7.6 7.x; do
+        for branch in master main 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
             # Checkout and update current branch
             exists=$(git branch -a --list "$branch" --list "origin/$branch")
             if [ -n "$exists" ]; then


### PR DESCRIPTION
This is due to the proprietary naming of branches in the
styleguide project.