### PR TITLE
[TASK] Improve handling of branches

### DIFF
--- a/bashScripts/collect-stats.sh
+++ b/bashScripts/collect-stats.sh
@@ -66,7 +66,7 @@ for user in $users; do
         cd "$userdir/$repo"
         for branch in main master latest 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
             # Checkout and update current branch
-            exists=$(git branch -a --list "$branch" --list "origin/$branch")
+            exists=$(git branch -a --list "origin/$branch")
             if [ -n "$exists" ]; then
                 git checkout $branch || exitMsg "checkout $branch in $repo"
                 git reset --hard origin/$branch || exitMsg "reset --hard origin/$branch in $repo"

--- a/bashScripts/collect-stats.sh
+++ b/bashScripts/collect-stats.sh
@@ -64,7 +64,7 @@ for user in $users; do
         fi
         latestbranch=""
         cd "$userdir/$repo"
-        for branch in master main 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
+        for branch in main master latest 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
             # Checkout and update current branch
             exists=$(git branch -a --list "$branch" --list "origin/$branch")
             if [ -n "$exists" ]; then
@@ -78,7 +78,7 @@ for user in $users; do
             fi
 
             # Collect automatic screenshots statistics
-            if echo "master main 11.5 11.x 11" | grep -w "$branch"; then
+            if echo "main master latest 11.5 11.x 11" | grep -w "$branch"; then
                 documentationFolders=$(find . -type d -name "Documentation")
                 for documentationFolder in $documentationFolders; do
                     numImages=$(find "$documentationFolder" -type f \( -iname "*.png" -or -iname "*.jpg" -or -iname "*.jpeg" -or -iname "*.gif" -or -iname "*.webp" \) | wc -l)

--- a/bashScripts/get-repos.sh
+++ b/bashScripts/get-repos.sh
@@ -65,11 +65,11 @@ for user in $users; do
             echo "$repo already exists: Update remote tracking branches, checkout and update main branch."
             cd "$repo"
             # Update remote tracking branches
-            git fetch || exitMsg "fetch $repo"
+            git fetch --prune || exitMsg "fetch $repo"
             # Checkout and update main branch
             mainbranch=""
             for branch in main master latest; do
-                exists=$(git branch -a --list "$branch" --list "origin/$branch")
+                exists=$(git branch -a --list "origin/$branch")
                 if [ -n "$exists" ]; then
                     mainbranch="$branch"
                     break

--- a/bashScripts/get-repos.sh
+++ b/bashScripts/get-repos.sh
@@ -68,7 +68,7 @@ for user in $users; do
             git fetch || exitMsg "fetch $repo"
             # Checkout and update main branch
             mainbranch=""
-            for branch in master main; do
+            for branch in main master latest; do
                 exists=$(git branch -a --list "$branch" --list "origin/$branch")
                 if [ -n "$exists" ]; then
                     mainbranch="$branch"

--- a/bashScripts/grep-for-settings.sh
+++ b/bashScripts/grep-for-settings.sh
@@ -66,7 +66,7 @@ for user in $users; do
         fi
         latestbranch=""
         cd "$userdir/$repo"
-        for branch in master main 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
+        for branch in main master latest 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
             # Checkout and update current branch
             exists=$(git branch -a --list "$branch" --list "origin/$branch")
             if [ -n "$exists" ]; then

--- a/bashScripts/grep-for-settings.sh
+++ b/bashScripts/grep-for-settings.sh
@@ -68,7 +68,7 @@ for user in $users; do
         cd "$userdir/$repo"
         for branch in main master latest 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
             # Checkout and update current branch
-            exists=$(git branch -a --list "$branch" --list "origin/$branch")
+            exists=$(git branch -a --list "origin/$branch")
             if [ -n "$exists" ]; then
                 echo "$repo ($branch): Searching .."
                 git checkout $branch || exitMsg "checkout $branch in $repo"

--- a/bashScripts/search-repos.sh
+++ b/bashScripts/search-repos.sh
@@ -70,7 +70,7 @@ for user in $users; do
         cd "$userdir/$repo"
         for branch in main master latest 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
             # Checkout and update current branch
-            exists=$(git branch -a --list "$branch" --list "origin/$branch")
+            exists=$(git branch -a --list "origin/$branch")
             if [ -n "$exists" ]; then
                 git checkout $branch || exitMsg "checkout $branch in $repo"
                 git reset --hard origin/$branch || exitMsg "reset --hard origin/$branch in $repo"

--- a/bashScripts/search-repos.sh
+++ b/bashScripts/search-repos.sh
@@ -68,7 +68,7 @@ for user in $users; do
         fi
         latestbranch=""
         cd "$userdir/$repo"
-        for branch in master main 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
+        for branch in main master latest 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
             # Checkout and update current branch
             exists=$(git branch -a --list "$branch" --list "origin/$branch")
             if [ -n "$exists" ]; then


### PR DESCRIPTION
During the current documentation standard run (see https://github.com/TYPO3-Documentation/T3DocTeam/issues/181 and https://github.com/TYPO3-Documentation/T3DocTeam/issues/182) two specific situations regarding branch names had to be handled:

(1) The remote main branch was renamed from "master" to "main" which let the tools run fail due to a missing remote equivalent of the local previously checked out "master" branch.
(2) The remote main branch name was "latest" instead of "master" or "main".

Both situations are handled with this patch.