### PR TITLE
[FEATURE] Support GitLab besides GitHub repositories 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,13 +64,14 @@ get-repo-names.php
 
 List the remote repos::
 
-    php get-repo-names.php [<type>] [<host>] [<user>] [<token>]
+    php get-repo-names.php [<type>] [<host>] [<user>] [<token>] [<force>]
 
     Arguments:
        type: Consider all repositories or only those starting with "TYPO3CMS-" (all, docs). [default: "docs"]
        host: Consider the repositories of this host (all, github.com, ..), which has to be defined in the /config.yml or /config.local.yml. [default: "github.com"]
        user: Consider the repositories of this user namespace (all, github.com:friendsoftypo3, github.com:typo3, github.com:typo3-documentation, ..), which has to be defined in the /config.yml or /config.local.yml. [default: "github.com:typo3-documentation"]
        token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: ""]
+       force: Allow user namespaces not configured in the /config.yml or /config.local.yml. Requires a specific user namespace, not the generic "all". [default: 0]
 
 Example::
 
@@ -81,13 +82,14 @@ get-repo-branches.php
 
 List the branches of the remote repos::
 
-    php get-repo-branches.php [<type>] [<host>] [<user>] [<token>]
+    php get-repo-branches.php [<type>] [<host>] [<user>] [<token>] [<force>]
 
     Arguments:
        type: Consider all repositories or only those starting with "TYPO3CMS-" (all, docs). [default: "docs"]
        host: Consider the repositories of this host (all, github.com, ..), which has to be defined in the /config.yml or /config.local.yml. [default: "github.com"]
        user: Consider the repositories of this user namespace (all, github.com:friendsoftypo3, github.com:typo3, github.com:typo3-documentation, ..), which has to be defined in the /config.yml or /config.local.yml. [default: "github.com:typo3-documentation"]
        token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: ""]
+       force: Allow user namespaces not configured in the /config.yml or /config.local.yml. Requires a specific user namespace, not the generic "all". [default: 0]
 
 Example::
 
@@ -98,7 +100,7 @@ get-contributors.php
 
 List the contributors of the remote repos or a specific repo::
 
-    php get-contributors.php [<year>] [<month>] [<type>] [<host>] [<user>] [<repo>] [<token>]
+    php get-contributors.php [<year>] [<month>] [<type>] [<host>] [<user>] [<repo>] [<token>] [<force>]
 
     Arguments:
        year: Consider commits of this year, "0" means the current year. [default: "0"]
@@ -108,6 +110,7 @@ List the contributors of the remote repos or a specific repo::
        user: Consider the repositories of this user namespace (all, github.com:friendsoftypo3, github.com:typo3, github.com:typo3-documentation, ..), which has to be defined in the /config.yml or /config.local.yml. [default: "github.com:typo3-documentation"]
        repo: Consider commits of this specific repository, "" means of all repositories. [default: ""]
        token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: ""]
+       force: Allow user namespaces not configured in the /config.yml or /config.local.yml. Requires a specific user namespace, not the generic "all". [default: 0]
 
 Example::
 
@@ -248,7 +251,7 @@ Set a remote "fork" repository if a given user namespace has a repository with a
     ./bash/modify-repos.sh set-fork <fork> [<host>] [<user>] [<token>]
 
     Arguments:
-       fork: Set a remote "fork" repository if this GitHub user namespace has a repository with a matching name.
+       fork: Set a remote "fork" repository if this user namespace has a repository with a matching name.
        host: Execute the action in the local repositories of this host (all, github.com, ..). Multiple hosts must be separated by space, e.g. "github.com gitlab.com". [default: "all"]
        user: Execute the action in the local repositories of this user namespace (all, github.com:friendsoftypo3, github.com:typo3, github.com:typo3-documentation, ..). Multiple users must be separated by space, e.g. "github.com:friendsoftypo3 github.com:typo3". [default: "all"]
        token: Use this GitHub / GitLab API token to overcome rate limitations. [default: ""]

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ t3docs-tools
 Suite of tools, mostly for bulk changes in the repositories of the TYPO3 Documentation
 Team and the TYPO3 Core Team, and to output some statistics, where
 
-* part of this is written in PHP (focused on remote actions in GitHub) and
+* part of this is written in PHP (with focus on remote actions in the VCS host) and
 * some of them are bash scripts (focused on local actions in the cloned repositories).
 
 Installation
@@ -40,19 +40,19 @@ configuration can be overridden with a custom, non version controlled
 `config.local.yml` file.
 
 The `bash/config.sh` file configures the local folder of the cloned repositories,
-which is generated-data/repos/ by default. The settings can be overridden with a custom
+which is generated-data/ by default. The settings can be overridden with a custom
 `bash/config.local.sh` file.
 
-The local repositories of each GitHub user namespace (officially "friendsoftypo3",
-"typo3" and "typo3-documentation") are cloned into local subfolders following
-the pattern generated-data/repos/<user>, i.e. currently into
+The local repositories of each user namespace (officially "friendsoftypo3", "typo3"
+and "typo3-documentation" of host "github.com") are cloned into local subfolders
+following the pattern generated-data/<host>/<user>, i.e. currently into
 
-* generated-data/repos/typo3-documentation/ and
-* generated-data/repos/typo3/ and
-* generated-data/repos/friendsoftypo3/,
+* generated-data/github.com/typo3-documentation/ and
+* generated-data/github.com/typo3/ and
+* generated-data/github.com/friendsoftypo3/,
 
-– for separate and general processing. Additional user namespaces can be defined
-in the config.yml and config.local.yml already mentioned.
+– for separate and general processing. Additional hosts and user namespaces can be
+defined in the config.yml and config.local.yml already mentioned.
 
 Usage: PHP
 ==========
@@ -64,58 +64,66 @@ get-repo-names.php
 
 List the remote repos::
 
-    php get-repo-names.php [<type>] [<user>] [<token>]
+    php get-repo-names.php [<type>] [<host>] [<user>] [<token>]
 
     Arguments:
        type: Consider all repositories or only those starting with "TYPO3CMS-" (all, docs). [default: "docs"]
-       user: Consider the repositories of this GitHub user namespace (friendsoftypo3, typo3, typo3-documentation, ...), which has to be defined in the /config.yml or /config.local.yml. [default: "typo3-documentation"]
-       token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: ""]
+       host: Consider the repositories of this host (all, github.com, ..), which has to be defined in the /config.yml or /config.local.yml. [default: "github.com"]
+       user: Consider the repositories of this user namespace (all, github.com:friendsoftypo3, github.com:typo3, github.com:typo3-documentation, ..), which has to be defined in the /config.yml or /config.local.yml. [default: "github.com:typo3-documentation"]
+       token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: ""]
 
 Example::
 
-    php get-repo-names.php docs typo3-documentation
+    php get-repo-names.php docs all github.com:typo3-documentation
 
 get-repo-branches.php
 ---------------------
 
 List the branches of the remote repos::
 
-    php get-repo-branches.php [<type>] [<user>] [<token>]
+    php get-repo-branches.php [<type>] [<host>] [<user>] [<token>]
 
     Arguments:
        type: Consider all repositories or only those starting with "TYPO3CMS-" (all, docs). [default: "docs"]
-       user: Consider the repositories of this GitHub user namespace (friendsoftypo3, typo3, typo3-documentation, ...), which has to be defined in the /config.yml or /config.local.yml. [default: "typo3-documentation"]
-       token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: ""]
+       host: Consider the repositories of this host (all, github.com, ..), which has to be defined in the /config.yml or /config.local.yml. [default: "github.com"]
+       user: Consider the repositories of this user namespace (all, github.com:friendsoftypo3, github.com:typo3, github.com:typo3-documentation, ..), which has to be defined in the /config.yml or /config.local.yml. [default: "github.com:typo3-documentation"]
+       token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: ""]
 
 Example::
 
-    php get-repo-branches.php all typo3
+    php get-repo-branches.php all all github.com:typo3
 
 get-contributors.php
 --------------------
 
 List the contributors of the remote repos or a specific repo::
 
-    php get-contributors.php [<year>] [<month>] [<type>] [<user>] [<repo>] [<token>]
+    php get-contributors.php [<year>] [<month>] [<type>] [<host>] [<user>] [<repo>] [<token>]
 
     Arguments:
        year: Consider commits of this year, "0" means the current year. [default: "0"]
        month: Consider commits of this month, "0" means all months. [default: "0"]
        type: Consider all repositories or only those starting with "TYPO3CMS-" (all, docs). [default: "docs"]
-       user: Consider the repositories of this GitHub user namespace (friendsoftypo3, typo3, typo3-documentation, ...), which has to be defined in the /config.yml or /config.local.yml. [default: "typo3-documentation"]
+       host: Consider the repositories of this host (all, github.com, ..), which has to be defined in the /config.yml or /config.local.yml. [default: "github.com"]
+       user: Consider the repositories of this user namespace (all, github.com:friendsoftypo3, github.com:typo3, github.com:typo3-documentation, ..), which has to be defined in the /config.yml or /config.local.yml. [default: "github.com:typo3-documentation"]
        repo: Consider commits of this specific repository, "" means of all repositories. [default: ""]
-       token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: ""]
+       token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: ""]
 
 Example::
 
-    php get-contributors.php 2021 8 all typo3-documentation t3docs-screenshots
+    php get-contributors.php 2021 8 all github.com typo3-documentation t3docs-screenshots
 
 generate-changelog-issue.php
 ----------------------------
 
 Create text for an issue including list of tasks to be checked off and link to original issue::
 
-    php generate-changelog-issue.php <url to changelog or version> [<changelog issue in T3DocsTeam>]
+    php generate-changelog-issue.php <url> [<issue>] [<token>]
+
+    Arguments:
+       url: Absolute changelog URL or TYPO3 version. For example "https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Index.html" or "11.5".
+       issue: ID of existing issue. If empty, all issues of changelog URL are printed. [default: ""]
+       token: Fetch the changelog issues using this GitHub API token to overcome rate limitations. [default: ""]
 
 Examples:
 
@@ -125,7 +133,7 @@ Create the text for a changelog issue for version 10.1::
 
 or::
 
-    php generate-changelog-issue.php "10.1"
+        php generate-changelog-issue.php "10.1"
 
 Show only the changelogs of the 12.0 branch that are not yet included in issue 121::
 
@@ -168,61 +176,64 @@ collect-stats.sh
 Collect statistics on all branches of all local repositories. Currently supported is the display of the number of
 automatically generated screenshots::
 
-    ./bash/collect-stats.sh [<type>] [<user>]
+    ./bash/collect-stats.sh [<type>] [<host>] [<user>]
 
     Arguments:
-       type: Collect the statistics of all repositories or only of those starting with "TYPO3CMS-" (all, docs). [default: "docs"]
-       user: Collect the statistics in the local repositories of this GitHub user namespace (all, friendsoftypo3, typo3, typo3-documentation, ..). Multiple users must be separated by space, e.g. "friendsoftypo3 typo3".  [default: "typo3-documentation"]
+       type: Collect the statistics of all repositories or only of those starting with "TYPO3CMS-" (all, docs). [default: "all"]
+       host: Collect the statistics in the local repositories of this host (all, github.com, ..). Multiple hosts must be separated by space, e.g. "github.com gitlab.com". [default: "all"]
+       user: Collect the statistics in the local repositories of this user namespace (all, github.com:friendsoftypo3, github.com:typo3, github.com:typo3-documentation, ..). Multiple users must be separated by space, e.g. "github.com:friendsoftypo3 github.com:typo3". [default: "all"]
 
 Example::
 
-    ./bash/collect-stats.sh all typo3
+    ./bash/collect-stats.sh all github.com typo3
 
-The repositories must already exist in generated-data/repos/. Call get-repos.sh to clone or update first.
+The repositories must already exist in generated-data/. Call get-repos.sh to clone or update first.
 
 exec-repos.sh
 -------------
 
 Execute a custom command in all branches of all local repositories::
 
-    ./bash/exec-repos.sh <command> [<user>]
+    ./bash/exec-repos.sh <command> [<host>] [<user>]
 
     Arguments:
        command: Execute this command in all branches of all local repositories. This parameter can also be the absolute file path of a bash script.
-       user: Execute the search command in the local repositories of this GitHub user namespace (all, friendsoftypo3, typo3, typo3-documentation, ..). Multiple users must be separated by space, e.g. "friendsoftypo3 typo3". [default: "typo3-documentation"]
+       host: Execute the command in the local repositories of this host (all, github.com, ..). Multiple hosts must be separated by space, e.g. "github.com gitlab.com". [default: "all"]
+       user: Execute the command in the local repositories of this user namespace (all, github.com:friendsoftypo3, github.com:typo3, github.com:typo3-documentation, ..). Multiple users must be separated by space, e.g. "github.com:friendsoftypo3 github.com:typo3". [default: "all"]
 
 Example - Command as string::
 
-    ./bash/exec-repos.sh "grep -rnIE '\`https://typo3\.org' --exclude-dir='.git' ." all
+    ./bash/exec-repos.sh "grep -rnIE '\`https://typo3\.org' --exclude-dir='.git' ." all all
 
 Example - Command in file::
 
     cp command/replace-and-push.sh.tmpl command/my-command.sh
     # adapt command/my-command.sh to your use case
-    ./bash/exec-repos.sh "$(pwd)/command/my-command.sh" typo3-documentation
+    ./bash/exec-repos.sh "$(pwd)/command/my-command.sh" github.com typo3-documentation
 
 The command file should be placed in the `command/` folder, where backups of meaningful production runs with file
 extension `.sh.tmpl` will be provided as templates and all custom command files with `.sh` are ignored by version
 control.
 
-The repositories must already exist in generated-data/repos/. Call get-repos.sh to clone or update first.
+The repositories must already exist in generated-data/. Call get-repos.sh to clone or update first.
 
 get-repos.sh
 ------------
 
 Clones all TYPO3 documentation repositories (all) or only those starting with \"TYPO3CMS-\" (docs)
-from remote to local folder generated-data/repos/::
+from remote to local folder generated-data/::
 
-    ./bash/get-repos.sh [<type>] [<user>] [<token>]
+    ./bash/get-repos.sh [<type>] [<host>] [<user>] [<token>]
 
     Arguments:
        type: Fetch all repositories or only those starting with "TYPO3CMS-" (all, docs). [default: "all"]
-       user: Fetch the repositories of this GitHub user namespace (all, friendsoftypo3, typo3, typo3-documentation, ..), which has to be defined in the /config.yml or /config.local.yml. Multiple users must be separated by space, e.g. "friendsoftypo3 typo3". [default: "typo3-documentation"]
-       token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: ""]
+       host: Fetch the repositories of this host (all, github.com, ..), which has to be defined in the /config.yml or /config.local.yml. Multiple hosts must be separated by space, e.g. "github.com gitlab.com". [default: "all"]
+       user: Fetch the repositories of this user namespace (all, github.com:friendsoftypo3, github.com:typo3, github.com:typo3-documentation, ..), which has to be defined in the /config.yml or /config.local.yml. Multiple users must be separated by space, e.g. "github.com:friendsoftypo3 github.com:typo3". [default: "all"]
+       token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: ""]
 
 Example::
 
-    ./bash/get-repos.sh docs typo3-documentation
+    ./bash/get-repos.sh docs all github.com:typo3-documentation
 
 modify-repos.sh
 ---------------
@@ -232,51 +243,54 @@ Modify the local repositories by a specific action.
 modify-repos.sh set-fork
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Set a remote "fork" repository if a given GitHub user namespace has a repository with a matching name::
+Set a remote "fork" repository if a given user namespace has a repository with a matching name::
 
-    ./bash/modify-repos.sh set-fork <fork> [<user>] [<token>]
+    ./bash/modify-repos.sh set-fork <fork> [<host>] [<user>] [<token>]
 
     Arguments:
        fork: Set a remote "fork" repository if this GitHub user namespace has a repository with a matching name.
-       user: Execute the action in the local repositories of this GitHub user namespace (all, friendsoftypo3, typo3, typo3-documentation, ..). Multiple users must be separated by space, e.g. "friendsoftypo3 typo3". [default: "typo3-documentation"]
-       token: Use this GitHub API token to overcome GitHub rate limitations. [default: ""]
+       host: Execute the action in the local repositories of this host (all, github.com, ..). Multiple hosts must be separated by space, e.g. "github.com gitlab.com". [default: "all"]
+       user: Execute the action in the local repositories of this user namespace (all, github.com:friendsoftypo3, github.com:typo3, github.com:typo3-documentation, ..). Multiple users must be separated by space, e.g. "github.com:friendsoftypo3 github.com:typo3". [default: "all"]
+       token: Use this GitHub / GitLab API token to overcome rate limitations. [default: ""]
 
 Example::
 
-    ./bash/modify-repos.sh set-fork marble
+    ./bash/modify-repos.sh set-fork marble github.com
 
-The repositories must already exist in generated-data/repos/. Call get-repos.sh to clone or update first.
+The repositories must already exist in generated-data/. Call get-repos.sh to clone or update first.
 
 versionbranch-exist.sh
 ----------------------
 
 Lists all local repositories for which a specific version branch exists::
 
-    ./bash/versionbranch-exist.sh <version> [<user>]
+    ./bash/versionbranch-exist.sh <version> [<host>] [<user>]
 
     Arguments:
        version: List all local repositories having a branch matching this version.
-       user: List local repositories of this GitHub user namespace (all, friendsoftypo3, typo3, typo3-documentation, ..). Multiple users must be separated by space, e.g. "friendsoftypo3 typo3". [default: "typo3-documentation"]
+       host: List local repositories of this host (all, github.com, ..). Multiple hosts must be separated by space, e.g. "github.com gitlab.com". [default: "all"]
+       user: List local repositories of this user namespace (all, github.com:friendsoftypo3, github.com:typo3, github.com:typo3-documentation, ..). Multiple users must be separated by space, e.g. "github.com:friendsoftypo3 github.com:typo3". [default: "all"]
 
 Example::
 
-    ./bash/versionbranch-exist.sh "7.6" typo3
+    ./bash/versionbranch-exist.sh "7.6" github.com typo3
 
-The repositories must already exist in generated-data/repos/. Call get-repos.sh to clone or update first.
+The repositories must already exist in generated-data/. Call get-repos.sh to clone or update first.
 
 versionbranch-not-exist.sh
 --------------------------
 
 Lists all local repositories for which a specific version branch does not exist::
 
-    ./bash/versionbranch-not-exist.sh <version> [<user>]
+    ./bash/versionbranch-not-exist.sh <version> [<host>] [<user>]
 
     Arguments:
        version: List all local repositories not having a branch matching this version.
-       user: List local repositories of this GitHub user namespace (all, friendsoftypo3, typo3, typo3-documentation, ..). Multiple users must be separated by space, e.g. "friendsoftypo3 typo3". [default: "typo3-documentation"]
+       host: List local repositories of this host (all, github.com, ..). Multiple hosts must be separated by space, e.g. "github.com gitlab.com". [default: "all"]
+       user: List local repositories of this user namespace (all, github.com:friendsoftypo3, github.com:typo3, github.com:typo3-documentation, ..). Multiple users must be separated by space, e.g. "github.com:friendsoftypo3 github.com:typo3". [default: "all"]
 
 Example::
 
-    ./bash/versionbranch-not-exist.sh "11.5" typo3-documentation
+    ./bash/versionbranch-not-exist.sh "11.5" all github.com:typo3-documentation
 
-The repositories must already exist in generated-data/repos/. Call get-repos.sh to clone or update first.
+The repositories must already exist in generated-data/. Call get-repos.sh to clone or update first.

--- a/bash/collect-stats.sh
+++ b/bash/collect-stats.sh
@@ -6,17 +6,18 @@ source "$thisdir/helpers.sh"
 
 function usage()
 {
-    echo "Usage: $0 [<type>] [<user>]"
+    echo "Usage: $0 [<type>] [<host>] [<user>]"
     echo ""
     echo "Arguments:"
-    echo "   type: Collect the statistics of all repositories or only of those starting with \"TYPO3CMS-\" (all, docs). [default: \"docs\"]"
-    echo "   user: Collect the statistics in the local repositories of this GitHub user namespace (all, $(getUsers 'all' ', ')). Multiple users must be separated by space, e.g. \"friendsoftypo3 typo3\". [default: \"typo3-documentation\"]"
+    echo "   type: Collect the statistics of all repositories or only of those starting with \"TYPO3CMS-\" (all, docs). [default: \"all\"]"
+    echo "   host: Collect the statistics in the local repositories of this host (all, $(getHosts 'all' ', ')). Multiple hosts must be separated by space, e.g. \"github.com gitlab.com\". [default: \"all\"]"
+    echo "   user: Collect the statistics in the local repositories of this user namespace (all, $(getUsers 'all' 'all' ', ')). Multiple users must be separated by space, e.g. \"github.com:friendsoftypo3 github.com:typo3\". [default: \"all\"]"
     exit 1
 }
 
 function handleRequest()
 {
-    if [ $# -le 2 ]; then
+    if [ $# -le 3 ]; then
         collectStats "$@"
     else
         usage
@@ -25,70 +26,85 @@ function handleRequest()
 
 function collectStats()
 {
-    local type="${1:-docs}"
-    local user="${2:-typo3-documentation}"
+    local type="${1:-all}"
+    local host="${2:-all}"
+    local user="${3:-all}"
 
-    local users=$(getUsers "$user" " ")
-    if [ -z "$users" ]; then
+    local hosts=$(getHosts "$host" " ")
+    local users=$(getUsers "$host" "$user" " ")
+    if [ -z "$hosts" ]; then
+        echo "Cannot find any configured host for given \"$host\" in /config.yml or /config.local.yml."
+        echo "---"
+        usage
+    elif [ -z "$users" ]; then
+        echo "Cannot find any configured user for given host \"$host\" and user \"$user\" in /config.yml or /config.local.yml."
+        echo "---"
         usage
     fi
 
     declare -A screenshots
 
-    for user in $users; do
-        userdir="$repodir/$user"
-
-        if [ ! -d "$userdir" ]; then
-            exitMsg "The TYPO3 repositories are not pulled to \"$userdir\" yet. Run get-repos.sh first."
-        fi
-
-        echo "------------------------------------------------------------------------"
-        echo "Collect stats command in local repositories of type \"$type\" of "
-        echo "$userdir/."
-        echo "------------------------------------------------------------------------"
-
-        cd "$userdir"
-        for repo in *; do
-            if [ ! -d "$userdir/$repo" ]; then
-                break;
+    for host in $hosts; do
+        for user in $users; do
+            if [[ ! $user =~ ^$host: ]]; then
+                continue
             fi
-            if [ "$type" = "docs" ] && [[ ! $repo =~ ^TYPO3CMS\- ]]; then
-                continue;
-            fi
-            latestbranch=""
-            cd "$userdir/$repo"
-            for branch in main master latest 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
-                # Checkout and update current branch
-                exists=$(git branch -a --list "origin/$branch")
-                if [ -n "$exists" ]; then
-                    git checkout -f $branch || exitMsg "checkout $branch in $repo"
-                    git reset --hard origin/$branch || exitMsg "reset --hard origin/$branch in $repo"
-                else
-                    continue
-                fi
-                if [ -z "$latestbranch" ]; then
-                    latestbranch="$branch"
-                fi
 
-                # Collect automatic screenshots statistics
-                if echo "main master latest 11.5 11.x 11" | grep -w "$branch"; then
-                    documentationFolders=$(find . -type d -name "Documentation")
-                    for documentationFolder in $documentationFolders; do
-                        numImages=$(find "$documentationFolder" -type f \( -iname "*.png" -or -iname "*.jpg" -or -iname "*.jpeg" -or -iname "*.gif" -or -iname "*.webp" \) | wc -l)
-                        numAutomatic=0
-                        automaticFolders=$(find "$documentationFolder" -type d -name "AutomaticScreenshots")
-                        for automaticFolder in $automaticFolders; do
-                            n=$(find "$automaticFolder" -type f \( -iname "*.png" -or -iname "*.jpg" -or -iname "*.jpeg" -or -iname "*.gif" -or -iname "*.webp" \) | wc -l)
-                            numAutomatic=$((numAutomatic+n))
+            user=$(echo "$user" | awk -F':' '{print $2}')
+            userdir="$repodir/$host/$user"
+
+            if [ ! -d "$userdir" ]; then
+                exitMsg "The TYPO3 repositories are not pulled to \"$userdir\" yet. Run get-repos.sh first."
+            fi
+
+            echo "------------------------------------------------------------------------"
+            echo "Collect stats command in local repositories of type \"$type\" of "
+            echo "$userdir/."
+            echo "------------------------------------------------------------------------"
+
+            cd "$userdir"
+            for repo in *; do
+                if [ ! -d "$userdir/$repo" ]; then
+                    break;
+                fi
+                if [ "$type" = "docs" ] && [[ ! $repo =~ ^TYPO3CMS\- ]]; then
+                    continue;
+                fi
+                latestbranch=""
+                cd "$userdir/$repo"
+                for branch in main master latest 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
+                    # Checkout and update current branch
+                    exists=$(git branch -a --list "origin/$branch")
+                    if [ -n "$exists" ]; then
+                        git checkout -f $branch || exitMsg "checkout $branch in $repo"
+                        git reset --hard origin/$branch || exitMsg "reset --hard origin/$branch in $repo"
+                    else
+                        continue
+                    fi
+                    if [ -z "$latestbranch" ]; then
+                        latestbranch="$branch"
+                    fi
+
+                    # Collect automatic screenshots statistics
+                    if echo "main master latest 11.5 11.x 11" | grep -w "$branch"; then
+                        documentationFolders=$(find . -type d -name "Documentation")
+                        for documentationFolder in $documentationFolders; do
+                            numImages=$(find "$documentationFolder" -type f \( -iname "*.png" -or -iname "*.jpg" -or -iname "*.jpeg" -or -iname "*.gif" -or -iname "*.webp" \) | wc -l)
+                            numAutomatic=0
+                            automaticFolders=$(find "$documentationFolder" -type d -name "AutomaticScreenshots")
+                            for automaticFolder in $automaticFolders; do
+                                n=$(find "$automaticFolder" -type f \( -iname "*.png" -or -iname "*.jpg" -or -iname "*.jpeg" -or -iname "*.gif" -or -iname "*.webp" \) | wc -l)
+                                numAutomatic=$((numAutomatic+n))
+                            done
+                            screenshots["$host/$user/$repo/$branch:$documentationFolder|all"]=$numImages
+                            screenshots["$host/$user/$repo/$branch:$documentationFolder|automatic"]=$numAutomatic
                         done
-                        screenshots["$user/$repo/$branch:$documentationFolder|all"]=$numImages
-                        screenshots["$user/$repo/$branch:$documentationFolder|automatic"]=$numAutomatic
-                    done
+                    fi
+                done
+                if [ -n "$latestbranch" ]; then
+                    git checkout -f $latestbranch
                 fi
             done
-            if [ -n "$latestbranch" ]; then
-                git checkout -f $latestbranch
-            fi
         done
     done
 

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -5,7 +5,7 @@ thisdir=$(dirname $(realpath "$0"))
 # default configuration
 phpdir=$(realpath "$thisdir/..")
 generateddir=$(realpath "$thisdir/../generated-data")
-repodir=$generateddir/repos
+repodir=$generateddir
 
 # override with custom configuration
 if [ -f $thisdir/config.local.sh ]; then

--- a/bash/exec-repos.sh
+++ b/bash/exec-repos.sh
@@ -6,17 +6,18 @@ source "$thisdir/helpers.sh"
 
 function usage()
 {
-    echo "Usage: $0 <command> [<user>]"
+    echo "Usage: $0 <command> [<host>] [<user>]"
     echo ""
     echo "Arguments:"
     echo "   command: Execute this command in all branches of all local repositories. This parameter can also be the absolute file path of a bash script."
-    echo "   user: Execute the command in the local repositories of this GitHub user namespace (all, $(getUsers 'all' ', ')). Multiple users must be separated by space, e.g. \"friendsoftypo3 typo3\". [default: \"typo3-documentation\"]"
+    echo "   host: Execute the command in the local repositories of this host (all, $(getHosts 'all' ', ')). Multiple hosts must be separated by space, e.g. \"github.com gitlab.com\". [default: \"all\"]"
+    echo "   user: Execute the command in the local repositories of this user namespace (all, $(getUsers 'all' 'all' ', ')). Multiple users must be separated by space, e.g. \"github.com:friendsoftypo3 github.com:typo3\". [default: \"all\"]"
     exit 1
 }
 
 function handleRequest()
 {
-    if [ $# -ge 1 ] && [ $# -le 2 ]; then
+    if [ $# -ge 1 ] && [ $# -le 3 ]; then
         execRepos "$@"
     else
         usage
@@ -26,10 +27,18 @@ function handleRequest()
 function execRepos()
 {
     local cmd="$1"
-    local user="${2:-typo3-documentation}"
+    local host="${2:-all}"
+    local user="${3:-all}"
 
-    local users=$(getUsers "$user" " ")
-    if [ -z "$users" ]; then
+    local hosts=$(getHosts "$host" " ")
+    local users=$(getUsers "$host" "$user" " ")
+    if [ -z "$hosts" ]; then
+        echo "Cannot find any configured host for given \"$host\" in /config.yml or /config.local.yml."
+        echo "---"
+        usage
+    elif [ -z "$users" ]; then
+        echo "Cannot find any configured user for given host \"$host\" and user \"$user\" in /config.yml or /config.local.yml."
+        echo "---"
         usage
     fi
 
@@ -42,64 +51,71 @@ function execRepos()
 
     declare -A execResults
 
-    for user in $users; do
-        userdir="$repodir/$user"
-
-        if [ ! -d "$userdir" ]; then
-            exitMsg "The TYPO3 repositories are not pulled to \"$userdir\" yet. Run get-repos.sh first."
-        fi
-
-        echo "------------------------------------------------------------------------"
-        echo "Run command "
-        echo "-"
-        echo "$cmd"
-        echo "-"
-        echo "in local repositories of "
-        echo "$userdir/."
-        echo "------------------------------------------------------------------------"
-
-        cd "$userdir"
-        for repo in *; do
-            if [ ! -d "$userdir/$repo" ]; then
-                break;
+    for host in $hosts; do
+        for user in $users; do
+            if [[ ! $user =~ ^$host: ]]; then
+                continue
             fi
-            latestbranch=""
-            cd "$userdir/$repo"
-            for branch in main master latest 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
-                # Checkout and update current branch
-                exists=$(git branch -a --list "origin/$branch")
-                if [ -n "$exists" ]; then
-                    git checkout -f $branch || exitMsg "checkout $branch in $repo"
-                    git reset --hard origin/$branch || exitMsg "reset --hard origin/$branch in $repo"
-                else
-                    continue
-                fi
-                if [ -z "$latestbranch" ]; then
-                    latestbranch="$branch"
-                fi
 
-                # Collect results
-                if [ $isCmdFile -eq 0 ]; then
-                    results=$(eval "$cmd")
-                else
-                    results=$(bash "$cmd")
+            user=$(echo "$user" | awk -F':' '{print $2}')
+            userdir="$repodir/$host/$user"
+
+            if [ ! -d "$userdir" ]; then
+                exitMsg "The TYPO3 repositories are not pulled to \"$userdir\" yet. Run get-repos.sh first."
+            fi
+
+            echo "------------------------------------------------------------------------"
+            echo "Run command "
+            echo "-"
+            echo "$cmd"
+            echo "-"
+            echo "in local repositories of "
+            echo "$userdir/."
+            echo "------------------------------------------------------------------------"
+
+            cd "$userdir"
+            for repo in *; do
+                if [ ! -d "$userdir/$repo" ]; then
+                    break;
                 fi
-                numResults=$(echo "$results" | wc -l)
-                if [ -n "$results" ] ; then
-                    execResults["$user/$repo/$branch|results"]=$results
-                    execResults["$user/$repo/$branch|numResults"]=$numResults
-                    if [ $stopOnFirstHit -eq 1 ]; then
-                        echo "Stopping on first hit."
-                        if [ -n "$latestbranch" ]; then
-                            git checkout -f $latestbranch
-                        fi
-                        break 3
+                latestbranch=""
+                cd "$userdir/$repo"
+                for branch in main master latest 11.5 11.x 11 10.4 10.x 10 9.5 9.x 9 8.7 8.x 8 7.6 7.x 7; do
+                    # Checkout and update current branch
+                    exists=$(git branch -a --list "origin/$branch")
+                    if [ -n "$exists" ]; then
+                        git checkout -f $branch || exitMsg "checkout $branch in $repo"
+                        git reset --hard origin/$branch || exitMsg "reset --hard origin/$branch in $repo"
+                    else
+                        continue
                     fi
+                    if [ -z "$latestbranch" ]; then
+                        latestbranch="$branch"
+                    fi
+
+                    # Collect results
+                    if [ $isCmdFile -eq 0 ]; then
+                        results=$(eval "$cmd")
+                    else
+                        results=$(bash "$cmd")
+                    fi
+                    numResults=$(echo "$results" | wc -l)
+                    if [ -n "$results" ] ; then
+                        execResults["$host/$user/$repo/$branch|results"]=$results
+                        execResults["$host/$user/$repo/$branch|numResults"]=$numResults
+                        if [ $stopOnFirstHit -eq 1 ]; then
+                            echo "Stopping on first hit."
+                            if [ -n "$latestbranch" ]; then
+                                git checkout -f $latestbranch
+                            fi
+                            break 4
+                        fi
+                    fi
+                done
+                if [ -n "$latestbranch" ]; then
+                    git checkout -f $latestbranch
                 fi
             done
-            if [ -n "$latestbranch" ]; then
-                git checkout -f $latestbranch
-            fi
         done
     done
 

--- a/bash/get-repos.sh
+++ b/bash/get-repos.sh
@@ -69,7 +69,7 @@ function getRepos()
             echo "$userdir/."
             echo "------------------------------------------------------------------------"
 
-            getRepoNames "$type" "$host" "$user" "$token" "\n" | while read repo; do
+            getRepoNames "$type" "$host" "$user" "$token" "0" "\n" | while read repo; do
                 cd "$userdir"
                 if [ ! -d "$repo" ]; then
                     echo "Cloning repo $repo."

--- a/bash/get-repos.sh
+++ b/bash/get-repos.sh
@@ -6,18 +6,19 @@ source "$thisdir/helpers.sh"
 
 function usage()
 {
-    echo "Usage: $0 [<type>] [<user>] [<token>]"
+    echo "Usage: $0 [<type>] [<host>] [<user>] [<token>]"
     echo ""
     echo "Arguments:"
     echo "   type: Fetch all repositories or only those starting with \"TYPO3CMS-\" (all, docs). [default: \"all\"]"
-    echo "   user: Fetch the repositories of this GitHub user namespace (all, $(getUsers 'all' ', ')), which has to be defined in the /config.yml or /config.local.yml. Multiple users must be separated by space, e.g. \"friendsoftypo3 typo3\". [default: \"typo3-documentation\"]"
-    echo "   token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: \"\"]"
+    echo "   host: Fetch the repositories of this host (all, $(getHosts 'all' ', ')), which has to be defined in the /config.yml or /config.local.yml. Multiple hosts must be separated by space, e.g. \"github.com gitlab.com\". [default: \"all\"]"
+    echo "   user: Fetch the repositories of this user namespace (all, $(getUsers 'all' 'all' ', ')), which has to be defined in the /config.yml or /config.local.yml. Multiple users must be separated by space, e.g. \"github.com:friendsoftypo3 github.com:typo3\". [default: \"all\"]"
+    echo "   token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: \"\"]"
     exit 1
 }
 
 function handleRequest()
 {
-    if [ $# -le 3 ]; then
+    if [ $# -le 4 ]; then
         getRepos "$@"
     else
         usage
@@ -27,56 +28,75 @@ function handleRequest()
 function getRepos()
 {
     local type="${1:-all}"
-    local user="${2:-typo3-documentation}"
-    local token="${3:-}"
+    local host="${2:-all}"
+    local user="${3:-all}"
+    local token="${4:-}"
 
     if [ "$type" != "all" ] && [ "$type" != "docs" ]; then
+        echo "The given type \"$type\" is invalid."
+        echo "---"
         usage
     fi
 
-    local users=$(getUsers "$user" " ")
-    if [ -z "$users" ]; then
+    local hosts=$(getHosts "$host" " ")
+    local users=$(getUsers "$host" "$user" " ")
+    if [ -z "$hosts" ]; then
+        echo "Cannot find any configured host for given \"$host\" in /config.yml or /config.local.yml."
+        echo "---"
+        usage
+    elif [ -z "$users" ]; then
+        echo "Cannot find any configured user for given host \"$host\" and user \"$user\" in /config.yml or /config.local.yml."
+        echo "---"
         usage
     fi
 
-    for user in $users; do
-        userdir="$repodir/$user"
+    declare -A hostsConfig=$(getHostsConfig "$host")
 
-        if ! mkdir -p "$userdir"; then
-            exitMsg "Error creating directory \"$userdir\"."
-        fi
-
-        echo "Clone or update local repositories of"
-        echo "$userdir/."
-        echo "------------------------------------------------------------------------"
-
-        php -f $phpdir/get-repo-names.php "$type" "$user" "$token" | while read repo; do
-            cd "$userdir"
-            if [ ! -d "$repo" ]; then
-                echo "Cloning repo $repo."
-                git clone "git@github.com:$user/$repo.git" || exitMsg "clone $repo"
-            else
-                echo "$repo already exists: Update remote tracking branches, checkout and update main branch."
-                cd "$repo"
-                # Update remote tracking branches
-                git fetch --prune || exitMsg "fetch $repo"
-                # Checkout and update main branch
-                mainbranch=""
-                for branch in main master latest; do
-                    exists=$(git branch -a --list "origin/$branch")
-                    if [ -n "$exists" ]; then
-                        mainbranch="$branch"
-                        break
-                    fi
-                done
-                if [ -n "$mainbranch" ]; then
-                    git checkout -f $mainbranch || exitMsg "checkout $mainbranch in $repo"
-                    git reset --hard origin/$mainbranch || exitMsg "reset --hard origin/$mainbranch in $repo"
-                else
-                    echo "The $repo repo is not yet initialized because it lacks a main branch."
-                fi
+    for host in $hosts; do
+        for user in $users; do
+            if [[ ! $user =~ ^$host: ]]; then
+                continue
             fi
+
+            user=$(echo "$user" | awk -F':' '{print $2}')
+            userdir="$repodir/$host/$user"
+
+            if ! mkdir -p "$userdir"; then
+                exitMsg "Error creating directory \"$userdir\"."
+            fi
+
+            echo "Clone or update local repositories of"
+            echo "$userdir/."
             echo "------------------------------------------------------------------------"
+
+            getRepoNames "$type" "$host" "$user" "$token" "\n" | while read repo; do
+                cd "$userdir"
+                if [ ! -d "$repo" ]; then
+                    echo "Cloning repo $repo."
+                    git clone $(printf ${hostsConfig["$host:ssh_url"]} "$user" "$repo") || exitMsg "clone $repo"
+                else
+                    echo "$repo already exists: Update remote tracking branches, checkout and update main branch."
+                    cd "$repo"
+                    # Update remote tracking branches
+                    git fetch --prune || exitMsg "fetch $repo"
+                    # Checkout and update main branch
+                    mainbranch=""
+                    for branch in main master latest; do
+                        exists=$(git branch -a --list "origin/$branch")
+                        if [ -n "$exists" ]; then
+                            mainbranch="$branch"
+                            break
+                        fi
+                    done
+                    if [ -n "$mainbranch" ]; then
+                        git checkout -f $mainbranch || exitMsg "checkout $mainbranch in $repo"
+                        git reset --hard origin/$mainbranch || exitMsg "reset --hard origin/$mainbranch in $repo"
+                    else
+                        echo "The $repo repo is not yet initialized because it lacks a main branch."
+                    fi
+                fi
+                echo "------------------------------------------------------------------------"
+            done
         done
     done
 }

--- a/bash/helpers.sh
+++ b/bash/helpers.sh
@@ -38,10 +38,11 @@ function getRepoNames()
     local host="$2"
     local user="$3"
     local token="$4"
-    local separator="$5"
+    local force="$5"
+    local separator="$6"
 
     local repos
-    repos=$(php -f $phpdir/get-repo-names.php "$type" "$host" "$user" "$token" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
+    repos=$(php -f $phpdir/get-repo-names.php "$type" "$host" "$user" "$token" "$force" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
     repos=$(echo $repos | sed "s/[[:space:]]/$separator/g")
     echo "$repos"
 }

--- a/bash/helpers.sh
+++ b/bash/helpers.sh
@@ -1,26 +1,48 @@
 #!/bin/bash
 
-function getUsers()
+function getHosts()
 {
-    local user="$1"
+    local host="$1"
     local separator="$2"
 
+    local hosts
+    hosts=$(php -f $phpdir/get-hosts.php "$host" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
+    hosts=$(echo $hosts | sed "s/[[:space:]]/$separator/g")
+    echo "$hosts"
+}
+
+function getHostsConfig()
+{
+    local host="$1"
+
+    local config
+    config=$(php -f $phpdir/get-hosts-config.php "$host")
+    echo "$config"
+}
+
+function getUsers()
+{
+    local host="$1"
+    local user="$2"
+    local separator="$3"
+
     local users
-    users=$(php -f $phpdir/get-users.php "$user" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
-    users=${users//[[:space:]]/$separator}
+    users=$(php -f $phpdir/get-users.php "$host" "$user" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
+    users=$(echo $users | sed "s/[[:space:]]/$separator/g")
     echo "$users"
 }
 
 function getRepoNames()
 {
     local type="$1"
-    local user="$2"
-    local token="$3"
-    local separator="$4"
+    local host="$2"
+    local user="$3"
+    local token="$4"
+    local separator="$5"
 
     local repos
-    repos=$(php -f $phpdir/get-repo-names.php "$type" "$user" "$token" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
-    repos=${repos//[[:space:]]/$separator}
+    repos=$(php -f $phpdir/get-repo-names.php "$type" "$host" "$user" "$token" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
+    repos=$(echo $repos | sed "s/[[:space:]]/$separator/g")
     echo "$repos"
 }
 

--- a/bash/modify-repos.sh
+++ b/bash/modify-repos.sh
@@ -6,12 +6,13 @@ source "$thisdir/helpers.sh"
 
 function usage()
 {
-    echo "Usage: $0 set-fork <fork> [<user>] [<token>]"
+    echo "Usage: $0 set-fork <fork> [<host>] [<user>] [<token>]"
     echo ""
     echo "Arguments:"
     echo "   fork: Set a remote \"fork\" repository if this GitHub user namespace has a repository with a matching name."
-    echo "   user: Execute the action in the local repositories of this GitHub user namespace (all, $(getUsers 'all' ', ')). Multiple users must be separated by space, e.g. \"friendsoftypo3 typo3\". [default: \"typo3-documentation\"]"
-    echo "   token: Use this GitHub API token to overcome GitHub rate limitations. [default: \"\"]"
+    echo "   host: Execute the action in the local repositories of this host (all, $(getHosts 'all' ', ')). Multiple hosts must be separated by space, e.g. \"github.com gitlab.com\". [default: \"all\"]"
+    echo "   user: Execute the action in the local repositories of this user namespace (all, $(getUsers 'all' 'all' ', ')). Multiple users must be separated by space, e.g. \"github.com:friendsoftypo3 github.com:typo3\". [default: \"all\"]"
+    echo "   token: Use this GitHub / GitLab API token to overcome rate limitations. [default: \"\"]"
     exit 1
 }
 
@@ -24,7 +25,7 @@ function handleAction()
     local action="$1"
 
     if [ "$action" = "set-fork" ]; then
-        if [ $# -le 3 ]; then
+        if [ $# -le 4 ]; then
             setFork "$@"
         else
             usage
@@ -37,53 +38,70 @@ function handleAction()
 function setFork()
 {
     local forkUser="${2:-}"
-    local user="${3:-typo3-documentation}"
-    local token="${4:-}"
+    local host="${3:-all}"
+    local user="${4:-all}"
+    local token="${5:-}"
 
     local quiet=0
     local stopOnFirstHit=0
-    local users=$(getUsers "$user" " ")
-    if [ -z "$users" ]; then
+    local hosts=$(getHosts "$host" " ")
+    local users=$(getUsers "$host" "$user" " ")
+    if [ -z "$hosts" ]; then
+        echo "Cannot find any configured host for given \"$host\" in /config.yml or /config.local.yml."
+        echo "---"
+        usage
+    elif [ -z "$users" ]; then
+        echo "Cannot find any configured user for given host \"$host\" and user \"$user\" in /config.yml or /config.local.yml."
+        echo "---"
         usage
     fi
     local forkRepos=""
     if [ -n "$forkUser" ]; then
-        forkRepos=$(getRepoNames "all" "$forkUser" "$token" " ")
+        forkRepos=$(getRepoNames "all" "$host" "$forkUser" "$token" " ")
     fi
 
+    declare -A hostsConfig=$(getHostsConfig "$host")
     declare -A modifyResults
 
-    for user in $users; do
-        userdir="$repodir/$user"
-
-        if [ ! -d "$userdir" ]; then
-            exitMsg "The TYPO3 repositories are not pulled to \"$userdir\" yet. Run get-repos.sh first."
-        fi
-
-        echo "Modify local repositories of $userdir/."
-
-        cd "$userdir"
-        for repo in *; do
-            if [ ! -d "$userdir/$repo" ]; then
-                break;
+    for host in $hosts; do
+        for user in $users; do
+            if [[ ! $user =~ ^$host: ]]; then
+                continue
             fi
-            cd "$userdir/$repo"
-            # Set "fork" remote
-            git remote remove fork &> /dev/null
-            if echo "$forkRepos" | grep -wq "$repo"; then
-                git remote add fork "git@github.com:$forkUser/$repo.git"
-                results="Repository https://github.com/$user/$repo has a fork."
-            else
-                results="Repository https://github.com/$user/$repo MISSES A FORK."
+
+            user=$(echo "$user" | awk -F':' '{print $2}')
+            userdir="$repodir/$host/$user"
+
+            if [ ! -d "$userdir" ]; then
+                exitMsg "The TYPO3 repositories are not pulled to \"$userdir\" yet. Run get-repos.sh first."
             fi
-            if [ -n "$results" ] ; then
-                modifyResults["$user/$repo|results"]=$results
-                modifyResults["$user/$repo|numResults"]=1
-                if [ $stopOnFirstHit -eq 1 ]; then
-                    echo "Stopping on first hit."
-                    break 2
+
+            echo "Modify local repositories of $userdir/."
+
+            cd "$userdir"
+            for repo in *; do
+                if [ ! -d "$userdir/$repo" ]; then
+                    break;
                 fi
-            fi
+                cd "$userdir/$repo"
+                # Set "fork" remote
+                git remote remove fork &> /dev/null
+                if echo "$forkRepos" | grep -wq "$repo"; then
+                    git remote add fork $(printf ${hostsConfig["$host:ssh_url"]} "$forkUser" "$repo")
+                    git fetch --prune fork
+                    results="Repository $(printf ${hostsConfig["$host:http_url"]} "$user" "$repo") has a fork."
+                else
+                    results="[MISSING] Repository $(printf ${hostsConfig["$host:http_url"]} "$user" "$repo") misses a fork."
+                fi
+                if [ -n "$results" ] ; then
+                    modifyResults["$host/$user/$repo|results"]=$results
+                    modifyResults["$host/$user/$repo|numResults"]=1
+                    if [ $stopOnFirstHit -eq 1 ]; then
+                        echo "Stopping on first hit."
+                        break 3
+                    fi
+                fi
+            done
         done
     done
 

--- a/bash/modify-repos.sh
+++ b/bash/modify-repos.sh
@@ -9,7 +9,7 @@ function usage()
     echo "Usage: $0 set-fork <fork> [<host>] [<user>] [<token>]"
     echo ""
     echo "Arguments:"
-    echo "   fork: Set a remote \"fork\" repository if this GitHub user namespace has a repository with a matching name."
+    echo "   fork: Set a remote \"fork\" repository if this user namespace has a repository with a matching name."
     echo "   host: Execute the action in the local repositories of this host (all, $(getHosts 'all' ', ')). Multiple hosts must be separated by space, e.g. \"github.com gitlab.com\". [default: \"all\"]"
     echo "   user: Execute the action in the local repositories of this user namespace (all, $(getUsers 'all' 'all' ', ')). Multiple users must be separated by space, e.g. \"github.com:friendsoftypo3 github.com:typo3\". [default: \"all\"]"
     echo "   token: Use this GitHub / GitLab API token to overcome rate limitations. [default: \"\"]"
@@ -57,7 +57,7 @@ function setFork()
     fi
     local forkRepos=""
     if [ -n "$forkUser" ]; then
-        forkRepos=$(getRepoNames "all" "$host" "$forkUser" "$token" " ")
+        forkRepos=$(getRepoNames "all" "$host" "$forkUser" "$token" "1" " ")
     fi
 
     declare -A hostsConfig=$(getHostsConfig "$host")

--- a/bash/versionbranch-not-exist.sh
+++ b/bash/versionbranch-not-exist.sh
@@ -6,17 +6,18 @@ source "$thisdir/helpers.sh"
 
 function usage()
 {
-    echo "Usage: $0 <version> [<user>]"
+    echo "Usage: $0 <version> [<host>] [<user>]"
     echo ""
     echo "Arguments:"
     echo "   version: List all local repositories not having a branch matching this version."
-    echo "   user: List local repositories of this GitHub user namespace (all, $(getUsers 'all' ', ')). Multiple users must be separated by space, e.g. \"friendsoftypo3 typo3\". [default: \"typo3-documentation\"]"
+    echo "   host: List local repositories of this host (all, $(getHosts 'all' ', ')). Multiple hosts must be separated by space, e.g. \"github.com gitlab.com\". [default: \"all\"]"
+    echo "   user: List local repositories of this user namespace (all, $(getUsers 'all' 'all' ', ')). Multiple users must be separated by space, e.g. \"github.com:friendsoftypo3 github.com:typo3\". [default: \"all\"]"
     exit 1
 }
 
 function handleRequest()
 {
-    if [ $# -ge 1 ] && [ $# -le 2 ]; then
+    if [ $# -ge 1 ] && [ $# -le 3 ]; then
         versionbranchNotExists "$@"
     else
         usage
@@ -26,32 +27,47 @@ function handleRequest()
 function versionbranchNotExists()
 {
     local version=$1
-    local user="${2:-typo3-documentation}"
+    local host="${2:-all}"
+    local user="${3:-all}"
 
-    local users=$(getUsers "$user" " ")
-    if [ -z "$users" ]; then
+    local hosts=$(getHosts "$host" " ")
+    local users=$(getUsers "$host" "$user" " ")
+    if [ -z "$hosts" ]; then
+        echo "Cannot find any configured host for given \"$host\" in /config.yml or /config.local.yml."
+        echo "---"
+        usage
+    elif [ -z "$users" ]; then
+        echo "Cannot find any configured user for given host \"$host\" and user \"$user\" in /config.yml or /config.local.yml."
+        echo "---"
         usage
     fi
 
-    for user in $users; do
-        userdir="$repodir/$user"
-
-        if [ ! -d "$userdir" ]; then
-            exitMsg "The TYPO3 repositories are not pulled to \"$userdir\" yet. Run get-repos.sh first."
-        fi
-
-        cd "$userdir"
-        for repo in *; do
-            if [ ! -d "$userdir/$repo" ]; then
-                break;
+    for host in $hosts; do
+        for user in $users; do
+            if [[ ! $user =~ ^$host: ]]; then
+                continue
             fi
 
-            cd "$userdir/$repo"
+            user=$(echo "$user" | awk -F':' '{print $2}')
+            userdir="$repodir/$host/$user"
 
-            git branch -a | grep "remotes\/origin\/$version" >/dev/null
-            if [ $? -ne 0 ]; then
-                echo "$user/$repo is missing version $version."
+            if [ ! -d "$userdir" ]; then
+                exitMsg "The TYPO3 repositories are not pulled to \"$userdir\" yet. Run get-repos.sh first."
             fi
+
+            cd "$userdir"
+            for repo in *; do
+                if [ ! -d "$userdir/$repo" ]; then
+                    break;
+                fi
+
+                cd "$userdir/$repo"
+
+                git branch -a | grep "remotes\/origin\/$version" >/dev/null
+                if [ $? -ne 0 ]; then
+                    echo "$host/$user/$repo is missing version $version."
+                fi
+            done
         done
     done
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,11 @@
     {
       "name": "Sybille Peters",
       "role": "Developer",
-      "homepage": "http://montagmorgen.at"
+      "homepage": "https://montagmorgen.at/"
+    },
+    {
+      "name": "Alexander Nitsche",
+      "role": "Developer"
     }
   ],
   "license": [

--- a/config.yml
+++ b/config.yml
@@ -7,8 +7,9 @@ general:
 hosts:
   github.com:
     type: github
-    api_url: "https://api.github.com/"
+    http_url: "https://github.com/%s/%s"
     ssh_url: "git@github.com:%s/%s.git"
+    api_url: "https://api.github.com/"
     repos:
       friendsoftypo3:
       typo3:
@@ -23,8 +24,9 @@ hosts:
 
 #  gitlab.com:
 #    type: gitlab
-#    api_url: "https://gitlab.com/api/v4/"
+#    http_url: "https://gitlab.com/%s/%s"
 #    ssh_url: "git@gitlab.com:%s/%s.git"
+#    api_url: "https://gitlab.com/api/v4/"
 #    repos:
 #      coderscare:
 #        include:

--- a/config.yml
+++ b/config.yml
@@ -4,17 +4,28 @@
 general:
   verbose: true
 
-github:
-  cmd:
-    baseURl:  https://api.github.com/
-  repos:
-    friendsoftypo3:
-    typo3:
-    typo3-documentation:
-      ignore:
-        - TYPO3CMS-Reference-FileAbstractionLayer
-        - TYPO3CMS-Tutorial-CreatingExtensions
-        - TYPO3CMS-Guide-Extbase
-    # typo3-console:
-      # include:
-        # - typo3-console
+hosts:
+  github.com:
+    type: github
+    api_url: "https://api.github.com/"
+    ssh_url: "git@github.com:%s/%s.git"
+    repos:
+      friendsoftypo3:
+      typo3:
+      typo3-documentation:
+        ignore:
+          - TYPO3CMS-Reference-FileAbstractionLayer
+          - TYPO3CMS-Tutorial-CreatingExtensions
+          - TYPO3CMS-Guide-Extbase
+      # typo3-console:
+        # include:
+          # - typo3-console
+
+#  gitlab.com:
+#    type: gitlab
+#    api_url: "https://gitlab.com/api/v4/"
+#    ssh_url: "git@gitlab.com:%s/%s.git"
+#    repos:
+#      coderscare:
+#        include:
+#          - gridelements

--- a/generate-changelog-issue.php
+++ b/generate-changelog-issue.php
@@ -2,41 +2,41 @@
 
 use T3docs\T3docsTools\Changelog\GenerateChangelogIssue;
 
+$loader = require 'vendor/autoload.php';
+
 function usage()
 {
-    print("php -f generate-changelog-issue.php <url to changelog or version> [id of existing issue]\n");
+    print("Usage: php generate-changelog-issue.php <url> [<issue>] [<token>]\n");
+    print("\n");
+    print("Arguments:\n");
+    print("   url: Absolute changelog URL or TYPO3 version. For example \"https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Index.html\" or \"11.5\".\n");
+    print("   issue: ID of existing issue. If empty, all issues of changelog URL are printed. [default: \"\"]\n");
+    print("   token: Fetch the changelog issues using this GitHub API token to overcome rate limitations. [default: \"\"]\n");
     exit(1);
 }
 
-if (!($argv[1] ?? false)) {
+if ($argc < 2 || $argc > 4) {
     usage();
 }
-$url = $argv[1];
 
-if (strpos($url, 'https:', 0) !== 0) {
+$url = $argv[1];
+$issue = $argv[2] ?? '';
+$token = $argv[3] ?? '';
+
+if (!str_starts_with($url, 'https:')) {
     $url = 'https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/' . $url . '/Index.html';
     print("Use url: $url\n");
 }
 
-$loader = require 'vendor/autoload.php';
-$changelog = new GenerateChangelogIssue();
+$changelog = new GenerateChangelogIssue($token);
 
-
-if ($argv[2] ?? false) {
-    // show new changelogs
-    $issueId = (int) ($argv[2]);
-    // load existing issue
+if (!empty($issue)) {
+    $issueId = (int)$issue;
     $result = $changelog->getChangesFromIssue($issueId);
-
-    //var_dump($result);
-    //exit(0);
-
     $changelog->getNewChangelogs($url);
     print("New changelogs\n");
     $changelog->printChangelogs();
-
 } else {
-    // show all changelogs
     $changes = $changelog->getChangelog($url);
     $changelog->printChangelogs();
 }

--- a/get-contributors.php
+++ b/get-contributors.php
@@ -2,53 +2,74 @@
 
 use T3docs\T3docsTools\Configuration;
 use T3docs\T3docsTools\GitHub\GithubRepository;
+use T3docs\T3docsTools\GitLab\GitLabRepository;
 
 $loader = require 'vendor/autoload.php';
 
 function usage()
 {
-    $users = (new Configuration())->getSortedFilteredUsers('all');
-    print("Usage: php get-contributors.php [<year>] [<month>] [<type>] [<user>] [<repo>] [<token>]\n");
+    $config = new Configuration();
+    $hosts = $config->getSortedFilteredHosts('all');
+    $users = $config->getSortedFilteredUsers('all', 'all');
+    print("Usage: php get-contributors.php [<year>] [<month>] [<type>] [<host>] [<user>] [<repo>] [<token>]\n");
     print("\n");
     print("Arguments:\n");
     print("   year: Consider commits of this year, \"0\" means the current year. [default: \"0\"]\n");
     print("   month: Consider commits of this month, \"0\" means all months. [default: \"0\"]\n");
     print("   type: Consider all repositories or only those starting with \"TYPO3CMS-\" (all, docs). [default: \"docs\"]\n");
-    print("   user: Consider the repositories of this GitHub user namespace (" . implode(', ', $users) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"typo3-documentation\"]\n");
+    print("   host: Consider the repositories of this host (all, " . implode(', ', $hosts) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"github.com\"]\n");
+    print("   user: Consider the repositories of this user namespace (all, " . implode(', ', $users) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"github.com:typo3-documentation\"]\n");
     print("   repo: Consider commits of this specific repository, \"\" means of all repositories. [default: \"\"]\n");
-    print("   token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: \"\"]\n");
+    print("   token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: \"\"]\n");
     exit(1);
 }
 
-if ($argc > 7) {
+if ($argc > 8) {
     usage();
 }
 
 $year = $argv[1] ?? 0;
 $month = $argv[2] ?? 0;
 $type = $argv[3] ?? 'docs';
-$user = $argv[4] ?? 'typo3-documentation';
-$repo = $argv[5] ?? '';
-$token = $argv[6] ?? '';
+$host = $argv[4] ?? 'github.com';
+$user = $argv[5] ?? 'github.com:typo3-documentation';
+$repo = $argv[6] ?? '';
+$token = $argv[7] ?? '';
 
-$gitRepository = new GithubRepository($token);
-$gitRepository->fetchRepos($user, $type);
-$contributors = $gitRepository->fetchContributors($repo, $year, $month);
+$config = new Configuration();
+$users = $config->getSortedFilteredUsers($host, $user);
 
-$year = $year == 0 ? intval(date("Y")) : $year;
-$filename = $month == 0 ? 'contributors-' . $year . '.csv' : 'contributors-' . $year . '_' . $month . '.csv';
-$file = fopen($filename, 'w');
-fwrite($file,"count,name,email,id\n");
-foreach($contributors as $id => $contributor) {
-    $line = $contributor['count'] . ',' . $contributor['name'] . ',' . $contributor['email'] . ',' . $id;
-    fwrite($file, $line . "\n");
+$contributors = [];
+foreach($users as $userIdentifier) {
+    list($host, $user) = explode(':', $userIdentifier, 2);
+    if ($config->getTypeOfHost($host) === Configuration::HOST_TYPE_GITHUB) {
+        $gitRepository = new GithubRepository($host, $token);
+        $gitRepository->fetchRepos($user, $type);
+        $contributors[$userIdentifier] = $gitRepository->fetchContributors($repo, $year, $month);
+    } elseif ($config->getTypeOfHost($host) === Configuration::HOST_TYPE_GITLAB) {
+        $gitRepository = new GitLabRepository($host, $token);
+        $gitRepository->fetchRepos($user, $type);
+        $contributors[$userIdentifier] = $gitRepository->fetchContributors($repo, $year, $month);
+    }
 }
-fclose($file);
 
-print("----------------------\n");
-print("------- Results ------\n");
-print("----------------------\n\n");
-print("Number of contributors:" . count($contributors) . "\n");
-print("Wrote list: $filename\n");
+foreach ($contributors as $userIdentifier => $contributorByUser) {
+    $namespace = empty($repo) ? "{$userIdentifier}" : "{$userIdentifier}:{$repo}";
+    $year = $year == 0 ? intval(date("Y")) : $year;
+    $date = $month == 0 ? "{$year}" : "{$year}_{$month}";
+    $filename = "contributors_{$namespace}_{$date}.csv";
 
+    $data = [];
+    $data[] = "count,name,email,id";
+    foreach ($contributorByUser as $id => $contributor) {
+        $data[] = $contributor['count'] . ',' . $contributor['name'] . ',' . $contributor['email'] . ',' . $id;
+    }
+    file_put_contents($filename, implode("\n", $data));
 
+    print("----------------------\n");
+    print("------- Results ------\n");
+    print("----------------------\n\n");
+    print("Namespace: $namespace \n");
+    print("Number of contributors: " . (count($data)-1) . "\n");
+    print("Wrote list: $filename\n");
+}

--- a/get-contributors.php
+++ b/get-contributors.php
@@ -11,7 +11,7 @@ function usage()
     $config = new Configuration();
     $hosts = $config->getSortedFilteredHosts('all');
     $users = $config->getSortedFilteredUsers('all', 'all');
-    print("Usage: php get-contributors.php [<year>] [<month>] [<type>] [<host>] [<user>] [<repo>] [<token>]\n");
+    print("Usage: php get-contributors.php [<year>] [<month>] [<type>] [<host>] [<user>] [<repo>] [<token>] [<force>]\n");
     print("\n");
     print("Arguments:\n");
     print("   year: Consider commits of this year, \"0\" means the current year. [default: \"0\"]\n");
@@ -21,10 +21,11 @@ function usage()
     print("   user: Consider the repositories of this user namespace (all, " . implode(', ', $users) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"github.com:typo3-documentation\"]\n");
     print("   repo: Consider commits of this specific repository, \"\" means of all repositories. [default: \"\"]\n");
     print("   token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: \"\"]\n");
+    print("   force: Allow user namespaces not configured in the /config.yml or /config.local.yml. Requires a specific user namespace, not the generic \"all\". [default: 0]\n");
     exit(1);
 }
 
-if ($argc > 8) {
+if ($argc > 9) {
     usage();
 }
 
@@ -35,9 +36,14 @@ $host = $argv[4] ?? 'github.com';
 $user = $argv[5] ?? 'github.com:typo3-documentation';
 $repo = $argv[6] ?? '';
 $token = $argv[7] ?? '';
+$force = (bool)($argv[8] ?? 0);
 
 $config = new Configuration();
-$users = $config->getSortedFilteredUsers($host, $user);
+if (!$force) {
+    $users = $config->getSortedFilteredUsers($host, $user);
+} else {
+    $users = $config->getSortedFilteredUsers($host, $user, Configuration::CHECK_HOST_ONLY);
+}
 
 $contributors = [];
 foreach($users as $userIdentifier) {

--- a/get-hosts-config.php
+++ b/get-hosts-config.php
@@ -25,7 +25,8 @@ $hosts = $config->getSortedFilteredHosts($host);
 print("(\n");
 foreach ($hosts as $host) {
     printf("[\"%s:type\"]=\"%s\"\n", $host, $config->getTypeOfHost($host));
-    printf("[\"%s:api_url\"]=\"%s\"\n", $host, $config->getApiUrlOfHost($host));
+    printf("[\"%s:http_url\"]=\"%s\"\n", $host, $config->getHttpUrlOfHost($host));
     printf("[\"%s:ssh_url\"]=\"%s\"\n", $host, $config->getSshUrlOfHost($host));
+    printf("[\"%s:api_url\"]=\"%s\"\n", $host, $config->getApiUrlOfHost($host));
 }
 print(")\n");

--- a/get-hosts-config.php
+++ b/get-hosts-config.php
@@ -6,10 +6,12 @@ $loader = require 'vendor/autoload.php';
 
 function usage()
 {
+    $config = new Configuration();
+    $hosts = $config->getSortedFilteredHosts('all');
     print("Usage: php get-hosts-config.php [<host>]\n");
     print("\n");
     print("Arguments:\n");
-    print("   host: Consider this host only, which has to be defined in the /config.yml or /config.local.yml. [default: \"all\"]\n");
+    print("   host: Consider this host only (all, " . implode(', ', $hosts) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"all\"]\n");
     exit(1);
 }
 

--- a/get-hosts-config.php
+++ b/get-hosts-config.php
@@ -1,0 +1,31 @@
+<?php
+
+use T3docs\T3docsTools\Configuration;
+
+$loader = require 'vendor/autoload.php';
+
+function usage()
+{
+    print("Usage: php get-hosts-config.php [<host>]\n");
+    print("\n");
+    print("Arguments:\n");
+    print("   host: Consider this host only, which has to be defined in the /config.yml or /config.local.yml. [default: \"all\"]\n");
+    exit(1);
+}
+
+if ($argc > 3) {
+    usage();
+}
+
+$host = $argv[1] ?? 'all';
+
+$config = new Configuration();
+$hosts = $config->getSortedFilteredHosts($host);
+
+print("(\n");
+foreach ($hosts as $host) {
+    printf("[\"%s:type\"]=\"%s\"\n", $host, $config->getTypeOfHost($host));
+    printf("[\"%s:api_url\"]=\"%s\"\n", $host, $config->getApiUrlOfHost($host));
+    printf("[\"%s:ssh_url\"]=\"%s\"\n", $host, $config->getSshUrlOfHost($host));
+}
+print(")\n");

--- a/get-hosts.php
+++ b/get-hosts.php
@@ -6,24 +6,22 @@ $loader = require 'vendor/autoload.php';
 
 function usage()
 {
-    print("Usage: php get-users.php [<host>] [<user>]\n");
+    print("Usage: php get-hosts.php [<host>]\n");
     print("\n");
     print("Arguments:\n");
     print("   host: Consider this host only, which has to be defined in the /config.yml or /config.local.yml. [default: \"all\"]\n");
-    print("   user: Consider this user namespace only, which has to be defined in the /config.yml or /config.local.yml. [default: \"all\"]\n");
     exit(1);
 }
 
-if ($argc > 3) {
+if ($argc > 2) {
     usage();
 }
 
 $host = $argv[1] ?? 'all';
-$user = $argv[2] ?? 'all';
 
 $config = new Configuration();
-$users = $config->getSortedFilteredUsers($host, $user);
+$hosts = $config->getSortedFilteredHosts($host);
 
-foreach($users as $user) {
-    print("$user\n");
+foreach($hosts as $host) {
+    print("$host\n");
 }

--- a/get-hosts.php
+++ b/get-hosts.php
@@ -6,10 +6,12 @@ $loader = require 'vendor/autoload.php';
 
 function usage()
 {
+    $config = new Configuration();
+    $hosts = $config->getSortedFilteredHosts('all');
     print("Usage: php get-hosts.php [<host>]\n");
     print("\n");
     print("Arguments:\n");
-    print("   host: Consider this host only, which has to be defined in the /config.yml or /config.local.yml. [default: \"all\"]\n");
+    print("   host: Consider this host only (all, " . implode(', ', $hosts) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"all\"]\n");
     exit(1);
 }
 

--- a/get-repo-branches.php
+++ b/get-repo-branches.php
@@ -2,38 +2,67 @@
 
 use T3docs\T3docsTools\Configuration;
 use T3docs\T3docsTools\GitHub\GithubRepository;
+use T3docs\T3docsTools\GitLab\GitLabRepository;
 
 $loader = require 'vendor/autoload.php';
 
 function usage()
 {
-    $users = (new Configuration())->getSortedFilteredUsers('all');
-    print("Usage: php get-repo-branches.php [<type>] [<user>] [<token>]\n");
+    $config = new Configuration();
+    $hosts = $config->getSortedFilteredHosts('all');
+    $users = $config->getSortedFilteredUsers('all', 'all');
+    print("Usage: php get-repo-branches.php [<type>] [<host>] [<user>] [<token>]\n");
     print("\n");
     print("Arguments:\n");
     print("   type: Consider all repositories or only those starting with \"TYPO3CMS-\" (all, docs). [default: \"docs\"]\n");
-    print("   user: Consider the repositories of this GitHub user namespace (" . implode(', ', $users) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"typo3-documentation\"]\n");
-    print("   token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: \"\"]\n");
+    print("   host: Consider the repositories of this host (all, " . implode(', ', $hosts) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"github.com\"]\n");
+    print("   user: Consider the repositories of this user namespace (all, " . implode(', ', $users) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"github.com:typo3-documentation\"]\n");
+    print("   token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: \"\"]\n");
     exit(1);
 }
 
-if ($argc > 4) {
+if ($argc > 5) {
     usage();
 }
 
 $type = $argv[1] ?? 'docs';
-$user = $argv[2] ?? 'typo3-documentation';
-$token = $argv[3] ?? '';
+$host = $argv[2] ?? 'github.com';
+$user = $argv[3] ?? 'github.com:typo3-documentation';
+$token = $argv[4] ?? '';
 
-$gitRepository = new GithubRepository($token);
-$gitRepository->fetchRepos($user, $type);
-$repos = $gitRepository->getNames();
+$config = new Configuration();
+$users = $config->getSortedFilteredUsers($host, $user);
 
-foreach($repos as $repo) {
-    print("$repo\n");
+$repos = [];
+foreach ($users as $userIdentifier) {
+    list($host, $user) = explode(':', $userIdentifier, 2);
+    if ($config->getTypeOfHost($host) === Configuration::HOST_TYPE_GITHUB) {
+        $gitRepository = new GithubRepository($host, $token);
+        $gitRepository->fetchRepos($user, $type);
+        $repos[$userIdentifier] = $gitRepository->getNames();
+    } elseif ($config->getTypeOfHost($host) === Configuration::HOST_TYPE_GITLAB) {
+        $gitRepository = new GitLabRepository($host, $token);
+        $gitRepository->fetchRepos($user, $type);
+        $repos[$userIdentifier] = $gitRepository->getNames();
+    }
+}
 
-    $branches = $gitRepository->fetchBranchNamesOfRepo($user, $repo);
-    foreach ($branches as $branch) {
-        print("  $branch \n");
+foreach ($repos as $userIdentifier => $reposByUser) {
+    list($host, $user) = explode(':', $userIdentifier, 2);
+    foreach ($reposByUser as $repo) {
+        print("{$userIdentifier}:{$repo}\n");
+
+        $branches = [];
+        if ($config->getTypeOfHost($host) === Configuration::HOST_TYPE_GITHUB) {
+            $gitRepository = new GithubRepository($host, $token);
+            $branches = $gitRepository->fetchBranchNamesOfRepo($user, $repo);
+        } elseif ($config->getTypeOfHost($host) === Configuration::HOST_TYPE_GITLAB) {
+            $gitRepository = new GitLabRepository($host, $token);
+            $branches = $gitRepository->fetchBranchNamesOfRepo($user, $repo);
+        }
+
+        foreach ($branches as $branch) {
+            print("  $branch \n");
+        }
     }
 }

--- a/get-repo-branches.php
+++ b/get-repo-branches.php
@@ -11,17 +11,18 @@ function usage()
     $config = new Configuration();
     $hosts = $config->getSortedFilteredHosts('all');
     $users = $config->getSortedFilteredUsers('all', 'all');
-    print("Usage: php get-repo-branches.php [<type>] [<host>] [<user>] [<token>]\n");
+    print("Usage: php get-repo-branches.php [<type>] [<host>] [<user>] [<token>] [<force>]\n");
     print("\n");
     print("Arguments:\n");
     print("   type: Consider all repositories or only those starting with \"TYPO3CMS-\" (all, docs). [default: \"docs\"]\n");
     print("   host: Consider the repositories of this host (all, " . implode(', ', $hosts) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"github.com\"]\n");
     print("   user: Consider the repositories of this user namespace (all, " . implode(', ', $users) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"github.com:typo3-documentation\"]\n");
     print("   token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: \"\"]\n");
+    print("   force: Allow user namespaces not configured in the /config.yml or /config.local.yml. Requires a specific user namespace, not the generic \"all\". [default: 0]\n");
     exit(1);
 }
 
-if ($argc > 5) {
+if ($argc > 6) {
     usage();
 }
 
@@ -29,9 +30,14 @@ $type = $argv[1] ?? 'docs';
 $host = $argv[2] ?? 'github.com';
 $user = $argv[3] ?? 'github.com:typo3-documentation';
 $token = $argv[4] ?? '';
+$force = (bool)($argv[5] ?? 0);
 
 $config = new Configuration();
-$users = $config->getSortedFilteredUsers($host, $user);
+if (!$force) {
+    $users = $config->getSortedFilteredUsers($host, $user);
+} else {
+    $users = $config->getSortedFilteredUsers($host, $user, Configuration::CHECK_HOST_ONLY);
+}
 
 $repos = [];
 foreach ($users as $userIdentifier) {

--- a/get-repo-names.php
+++ b/get-repo-names.php
@@ -11,17 +11,18 @@ function usage()
     $config = new Configuration();
     $hosts = $config->getSortedFilteredHosts('all');
     $users = $config->getSortedFilteredUsers('all', 'all');
-    print("Usage: php get-repo-names.php [<type>] [<host>] [<user>] [<token>]\n");
+    print("Usage: php get-repo-names.php [<type>] [<host>] [<user>] [<token>] [<force>]\n");
     print("\n");
     print("Arguments:\n");
     print("   type: Consider all repositories or only those starting with \"TYPO3CMS-\" (all, docs). [default: \"docs\"]\n");
     print("   host: Consider the repositories of this host (all, " . implode(', ', $hosts) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"github.com\"]\n");
     print("   user: Consider the repositories of this user namespace (all, " . implode(', ', $users) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"github.com:typo3-documentation\"]\n");
     print("   token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: \"\"]\n");
+    print("   force: Allow user namespaces not configured in the /config.yml or /config.local.yml. Requires a specific user namespace, not the generic \"all\". [default: 0]\n");
     exit(1);
 }
 
-if ($argc > 5) {
+if ($argc > 6) {
     usage();
 }
 
@@ -29,9 +30,14 @@ $type = $argv[1] ?? 'docs';
 $host = $argv[2] ?? 'github.com';
 $user = $argv[3] ?? 'github.com:typo3-documentation';
 $token = $argv[4] ?? '';
+$force = (bool)($argv[5] ?? 0);
 
 $config = new Configuration();
-$users = $config->getSortedFilteredUsers($host, $user);
+if (!$force) {
+    $users = $config->getSortedFilteredUsers($host, $user);
+} else {
+    $users = $config->getSortedFilteredUsers($host, $user, Configuration::CHECK_HOST_ONLY);
+}
 
 $repos = [];
 foreach ($users as $userIdentifier) {

--- a/get-repo-names.php
+++ b/get-repo-names.php
@@ -2,32 +2,45 @@
 
 use T3docs\T3docsTools\Configuration;
 use T3docs\T3docsTools\GitHub\GithubRepository;
+use T3docs\T3docsTools\GitLab\GitLabRepository;
 
 $loader = require 'vendor/autoload.php';
 
 function usage()
 {
-    $users = (new Configuration())->getSortedFilteredUsers('all');
-    print("Usage: php get-repo-names.php [<type>] [<user>] [<token>]\n");
+    $config = new Configuration();
+    $hosts = $config->getSortedFilteredHosts('all');
+    $users = $config->getSortedFilteredUsers('all', 'all');
+    print("Usage: php get-repo-names.php [<type>] [<host>] [<user>] [<token>]\n");
     print("\n");
     print("Arguments:\n");
     print("   type: Consider all repositories or only those starting with \"TYPO3CMS-\" (all, docs). [default: \"docs\"]\n");
-    print("   user: Consider the repositories of this GitHub user namespace (" . implode(', ', $users) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"typo3-documentation\"]\n");
-    print("   token: Fetch the repositories using this GitHub API token to overcome GitHub rate limitations. [default: \"\"]\n");
+    print("   host: Consider the repositories of this host (" . implode(', ', $hosts) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"github.com\"]\n");
+    print("   user: Consider the repositories of this user namespace (" . implode(', ', $users) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"github.com:typo3-documentation\"]\n");
+    print("   token: Fetch the repositories using this GitHub / GitLab API token to overcome rate limitations. [default: \"\"]\n");
     exit(1);
 }
 
-if ($argc > 4) {
+if ($argc > 5) {
     usage();
 }
 
 $type = $argv[1] ?? 'docs';
-$user = $argv[2] ?? 'typo3-documentation';
-$token = $argv[3] ?? '';
+$host = $argv[2] ?? 'github.com';
+$user = $argv[3] ?? 'github.com:typo3-documentation';
+$token = $argv[4] ?? '';
 
-$gitRepository = new GithubRepository($token);
-$gitRepository->fetchRepos($user, $type);
-$repos = $gitRepository->getNames();
+$config = new Configuration();
+$repos = [];
+if ($config->getTypeOfHost($host) === Configuration::HOST_TYPE_GITHUB) {
+    $gitRepository = new GithubRepository($host, $token);
+    $gitRepository->fetchRepos($user, $type);
+    $repos = $gitRepository->getNames();
+} elseif ($config->getTypeOfHost($host) === Configuration::HOST_TYPE_GITLAB) {
+    $gitRepository = new GitLabRepository($host, $token);
+    $gitRepository->fetchRepos($user, $type);
+    $repos = $gitRepository->getNames();
+}
 
 foreach($repos as $repo) {
     print("$repo\n");

--- a/get-users.php
+++ b/get-users.php
@@ -6,11 +6,14 @@ $loader = require 'vendor/autoload.php';
 
 function usage()
 {
+    $config = new Configuration();
+    $hosts = $config->getSortedFilteredHosts('all');
+    $users = $config->getSortedFilteredUsers('all', 'all');
     print("Usage: php get-users.php [<host>] [<user>]\n");
     print("\n");
     print("Arguments:\n");
-    print("   host: Consider this host only, which has to be defined in the /config.yml or /config.local.yml. [default: \"all\"]\n");
-    print("   user: Consider this user namespace only, which has to be defined in the /config.yml or /config.local.yml. [default: \"all\"]\n");
+    print("   host: Consider this host only (all, " . implode(', ', $hosts) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"all\"]\n");
+    print("   user: Consider this user namespace only (all, " . implode(', ', $users) . "), which has to be defined in the /config.yml or /config.local.yml. [default: \"all\"]\n");
     exit(1);
 }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -9,6 +9,9 @@ class Configuration
     public const HOST_TYPE_GITHUB = 'github';
     public const HOST_TYPE_GITLAB = 'gitlab';
 
+    public const CHECK_HOST_AND_USER = 0;
+    public const CHECK_HOST_ONLY = 1;
+
     /** @var Configuration */
     public static $instance;
 
@@ -79,7 +82,7 @@ class Configuration
         return $this->config['hosts'][$host]['api_url'] ?? '';
     }
 
-    public function getFilteredUsers(string $host, string $user): array
+    public function getFilteredUsers(string $host, string $user, int $filterType = self::CHECK_HOST_AND_USER): array
     {
         $filteredUsers = [];
         $hosts = $this->getFilteredHosts($host);
@@ -95,7 +98,11 @@ class Configuration
                 $filter = explode(" ", $user);
                 $filter = array_filter($filter, function($u) use ($h) { return $this->isUserIdentifierOfHost($h, $u); });
                 $filter = array_map(function($u) use ($h) { return $this->extractFromUserIdentifier($u, 'user'); }, $filter);
-                $users = array_intersect($users, $filter);
+                if ($filterType === self::CHECK_HOST_AND_USER) {
+                    $users = array_intersect($users, $filter);
+                } elseif ($filterType === self::CHECK_HOST_ONLY) {
+                    $users = $filter;
+                }
                 $usersIdentifiers = array_map(function($u) use ($h) { return $this->composeUserIdentifier($h, $u); }, $users);
                 $filteredUsers = array_merge($filteredUsers, $usersIdentifiers);
             }
@@ -123,9 +130,9 @@ class Configuration
         return $host . ':' . $user;
     }
 
-    public function getSortedFilteredUsers(string $host, string $user): array
+    public function getSortedFilteredUsers(string $host, string $user, int $filterType = self::CHECK_HOST_AND_USER): array
     {
-        $users = $this->getFilteredUsers($host, $user);
+        $users = $this->getFilteredUsers($host, $user, $filterType);
         natcasesort($users);
         return $users;
     }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -6,6 +6,9 @@ use Symfony\Component\Yaml\Yaml;
 
 class Configuration
 {
+    public const HOST_TYPE_GITHUB = 'github';
+    public const HOST_TYPE_GITLAB = 'gitlab';
+
     /** @var Configuration */
     public static $instance;
 
@@ -37,32 +40,98 @@ class Configuration
         return self::$instance;
     }
 
-    public function getFilteredUsers(string $user): array
+    public function getFilteredHosts(string $host): array
     {
-        $users = isset($this->config['github']['repos']) ?
-            array_keys($this->config['github']['repos']) : [];
+        $hosts = isset($this->config['hosts']) ?
+            array_keys($this->config['hosts']) : [];
 
-        if (empty($user) || $user === 'all') {
-            return $users;
+        if (empty($host) || $host === 'all') {
+            return $hosts;
         } else {
-            return array_intersect($users, explode(" ", $user));
+            return array_intersect($hosts, explode(" ", $host));
         }
     }
 
-    public function getSortedFilteredUsers(string $user): array
+    public function getSortedFilteredHosts(string $host): array
     {
-        $users = $this->getFilteredUsers($user);
+        $hosts = $this->getFilteredHosts($host);
+        natcasesort($hosts);
+        return $hosts;
+    }
+
+    public function getTypeOfHost(string $host): string
+    {
+        return $this->config['hosts'][$host]['type'] ?? '';
+    }
+
+    public function getApiUrlOfHost(string $host): string
+    {
+        return $this->config['hosts'][$host]['api_url'] ?? '';
+    }
+
+    public function getSshUrlOfHost(string $host): string
+    {
+        return $this->config['hosts'][$host]['ssh_url'] ?? '';
+    }
+
+    public function getFilteredUsers(string $host, string $user): array
+    {
+        $filteredUsers = [];
+        $hosts = $this->getFilteredHosts($host);
+
+        foreach ($hosts as $h) {
+            $users = isset($this->config['hosts'][$h]['repos']) ?
+                array_keys($this->config['hosts'][$h]['repos']) : [];
+
+            if (empty($user) || $user === 'all') {
+                $usersIdentifiers = array_map(function($u) use ($h) { return $this->composeUserIdentifier($h, $u); }, $users);
+                $filteredUsers = array_merge($filteredUsers, $usersIdentifiers);
+            } else {
+                $filter = explode(" ", $user);
+                $filter = array_filter($filter, function($u) use ($h) { return $this->isUserIdentifierOfHost($h, $u); });
+                $filter = array_map(function($u) use ($h) { return $this->extractFromUserIdentifier($u, 'user'); }, $filter);
+                $users = array_intersect($users, $filter);
+                $usersIdentifiers = array_map(function($u) use ($h) { return $this->composeUserIdentifier($h, $u); }, $users);
+                $filteredUsers = array_merge($filteredUsers, $usersIdentifiers);
+            }
+        }
+
+        return $filteredUsers;
+    }
+
+    protected function isUserIdentifierOfHost(string $host, string $userIdentifier): bool
+    {
+        return !str_contains($userIdentifier, ':') || str_starts_with($userIdentifier, $host.':');
+    }
+
+    protected function extractFromUserIdentifier(string $userIdentifier, string $part): string
+    {
+        $parts = ['host' => '', 'user' => $userIdentifier];
+        if (str_contains($userIdentifier, ':')) {
+            list($parts['host'], $parts['user']) = explode(':', $userIdentifier, 2);;
+        }
+        return $parts[$part];
+    }
+
+    protected function composeUserIdentifier(string $host, string $user): string
+    {
+        return $host . ':' . $user;
+    }
+
+    public function getSortedFilteredUsers(string $host, string $user): array
+    {
+        $users = $this->getFilteredUsers($host, $user);
         natcasesort($users);
         return $users;
     }
 
-    public function getIncludedRepos(string $user): array
+    public function getIncludedRepos(string $host, string $user): array
     {
-        return $this->config['github']['repos'][$user]['include'] ?? [];
+        return $this->config['hosts'][$host]['repos'][$user]['include'] ?? [];
     }
 
-    public function getIgnoredRepos(string $user): array
+    public function getIgnoredRepos(string $host, string $user): array
     {
-        return $this->config['github']['repos'][$user]['ignore'] ?? [];
+        return $this->config['hosts'][$host]['repos'][$user]['ignore'] ?? [];
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -64,14 +64,19 @@ class Configuration
         return $this->config['hosts'][$host]['type'] ?? '';
     }
 
-    public function getApiUrlOfHost(string $host): string
+    public function getHttpUrlOfHost(string $host): string
     {
-        return $this->config['hosts'][$host]['api_url'] ?? '';
+        return $this->config['hosts'][$host]['http_url'] ?? '';
     }
 
     public function getSshUrlOfHost(string $host): string
     {
         return $this->config['hosts'][$host]['ssh_url'] ?? '';
+    }
+
+    public function getApiUrlOfHost(string $host): string
+    {
+        return $this->config['hosts'][$host]['api_url'] ?? '';
     }
 
     public function getFilteredUsers(string $host, string $user): array

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -113,7 +113,7 @@ class Configuration
     {
         $parts = ['host' => '', 'user' => $userIdentifier];
         if (str_contains($userIdentifier, ':')) {
-            list($parts['host'], $parts['user']) = explode(':', $userIdentifier, 2);;
+            list($parts['host'], $parts['user']) = explode(':', $userIdentifier, 2);
         }
         return $parts[$part];
     }

--- a/src/GitHub/GitHubApi.php
+++ b/src/GitHub/GitHubApi.php
@@ -50,7 +50,7 @@ class GitHubApi
         try {
             $response = $this->client->request('GET', $url, $options);
         } catch (ClientException $e) {
-            print("HTTP {$e->getCode()} thrown for \"GET $url\": {$e->getMessage()}");
+            error_log("HTTP {$e->getCode()} thrown for \"GET $url\": {$e->getMessage()}");
             return [];
         }
         if ($response->getStatusCode() !== 200) {
@@ -63,16 +63,7 @@ class GitHubApi
     /**
      * Send GET HTTP request to GitHub API with support of pagination.
      *
-     * - by default, this returns only 30 commits
-     *   you can change the number of commits with per_page= (max 100)
-     * - you can get further pages with page=
-     *
-     * You MUST use the URLs supplied in the HTTP header link,
-     * example :
-     * Link: <https://api.github.com/repositories/54468502/commits?since=2019-01-01T00%3A00%3A00+01%3A00&until=2019-12-31T23%3A59%3A00+01%3A00&page=2>; rel="next", <https://api.github.com/repositories/54468502/commits?since=2019-01-01T00%3A00%3A00+01%3A00&until=2019-12-31T23%3A59%3A00+01%3A00&page=7>; rel="last"
-     *
-     * https://developer.github.com/v3/#pagination
-     * https://developer.github.com/v3/guides/traversing-with-pagination/
+     * See: https://docs.github.com/en/rest/guides/traversing-with-pagination
      *
      * @param string $url GitHub URL or path
      * @return array GitHub response object decoded
@@ -96,7 +87,7 @@ class GitHubApi
             try {
                 $response = $this->client->request('GET', $nextPageUrl, $options);
             } catch (ClientException $e) {
-                print("HTTP {$e->getCode()} thrown for \"GET $nextPageUrl\": {$e->getMessage()}");
+                error_log("HTTP {$e->getCode()} thrown for \"GET $nextPageUrl\": {$e->getMessage()}");
                 return [];
             }
             if ($response->getStatusCode() !== 200) {

--- a/src/GitHub/GithubRepository.php
+++ b/src/GitHub/GithubRepository.php
@@ -104,6 +104,12 @@ class GithubRepository
         return $branchNames;
     }
 
+    public function fetchIssue(string $user, string $repoName, int $issueId): array
+    {
+        $issue = $this->api->get("repos/$user/$repoName/issues/$issueId");
+        return $issue;
+    }
+
     /**
      * Load contributors of GitHub repositories via GitHub API.
      *

--- a/src/GitHub/GithubRepository.php
+++ b/src/GitHub/GithubRepository.php
@@ -127,7 +127,9 @@ class GithubRepository
             $commits = $this->getCommits($repo, $year, $month);
 
             foreach ($commits as $commit) {
-                $id = $commit['author']['id'];
+                $id = $commit['author']['id']
+                        ?? $commit['commit']['author']['email']
+                        ?? $commit['commit']['author']['name'];
                 if (!isset($contributors[$id])) {
                     $contributors[$id] = [
                         'name' => $commit['commit']['author']['name'],

--- a/src/GitLab/GitLabApi.php
+++ b/src/GitLab/GitLabApi.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace T3docs\T3docsTools\GitHub;
+namespace T3docs\T3docsTools\GitLab;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 
-class GitHubApi
+class GitLabApi
 {
     /**
      * @var Client Guzzle HTTP client
@@ -13,13 +13,13 @@ class GitHubApi
     protected $client;
 
     /**
-     * @var string GitHub access token
+     * @var string GitLab access token
      */
     protected $token;
 
     /**
      * @param string $baseUrl GitHub API base URL
-     * @param string $token GitHub access token
+     * @param string $token GitLab access token
      */
     public function __construct(string $baseUrl, string $token = '')
     {
@@ -30,10 +30,10 @@ class GitHubApi
     }
 
     /**
-     * Send GET HTTP request to GitHub API.
+     * Send GET HTTP request to GitLab API.
      *
-     * @param string $url GitHub URL or path
-     * @return array GitHub response object decoded
+     * @param string $url GitLab URL or path
+     * @return array GitLab response object decoded
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function get(string $url): array
@@ -42,7 +42,7 @@ class GitHubApi
         if (!empty($this->token)) {
             $options = [
                 'headers' => [
-                    'Authorization' => 'token ' . $this->token
+                    'Authorization' => 'Bearer ' . $this->token
                 ]
             ];
         }
@@ -61,21 +61,12 @@ class GitHubApi
     }
 
     /**
-     * Send GET HTTP request to GitHub API with support of pagination.
+     * Send GET HTTP request to GitLab API with support of pagination.
      *
-     * - by default, this returns only 30 commits
-     *   you can change the number of commits with per_page= (max 100)
-     * - you can get further pages with page=
+     * See: https://docs.gitlab.com/ee/api/#pagination
      *
-     * You MUST use the URLs supplied in the HTTP header link,
-     * example :
-     * Link: <https://api.github.com/repositories/54468502/commits?since=2019-01-01T00%3A00%3A00+01%3A00&until=2019-12-31T23%3A59%3A00+01%3A00&page=2>; rel="next", <https://api.github.com/repositories/54468502/commits?since=2019-01-01T00%3A00%3A00+01%3A00&until=2019-12-31T23%3A59%3A00+01%3A00&page=7>; rel="last"
-     *
-     * https://developer.github.com/v3/#pagination
-     * https://developer.github.com/v3/guides/traversing-with-pagination/
-     *
-     * @param string $url GitHub URL or path
-     * @return array GitHub response object decoded
+     * @param string $url GitLab URL or path
+     * @return array GitLab response object decoded
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function getAllWithPagination(string $url): array
@@ -84,7 +75,7 @@ class GitHubApi
         if (!empty($this->token)) {
             $options = [
                 'headers' => [
-                    'Authorization' => 'token ' . $this->token
+                    'Authorization' => 'Bearer ' . $this->token
                 ]
             ];
         }
@@ -110,9 +101,9 @@ class GitHubApi
     }
 
     /**
-     * Parse next page URL from GitHub API response.
+     * Parse next page URL from GitLab API response.
      *
-     * @param array $responseHeaders Headers of GitHub API response
+     * @param array $responseHeaders Headers of GitLab API response
      * @return string Next page URL
      */
     protected function getNextPageUrl(array $responseHeaders): string

--- a/src/GitLab/GitLabApi.php
+++ b/src/GitLab/GitLabApi.php
@@ -50,7 +50,7 @@ class GitLabApi
         try {
             $response = $this->client->request('GET', $url, $options);
         } catch (ClientException $e) {
-            print("HTTP {$e->getCode()} thrown for \"GET $url\": {$e->getMessage()}");
+            error_log("HTTP {$e->getCode()} thrown for \"GET $url\": {$e->getMessage()}");
             return [];
         }
         if ($response->getStatusCode() !== 200) {
@@ -87,7 +87,7 @@ class GitLabApi
             try {
                 $response = $this->client->request('GET', $nextPageUrl, $options);
             } catch (ClientException $e) {
-                print("HTTP {$e->getCode()} thrown for \"GET $nextPageUrl\": {$e->getMessage()}");
+                error_log("HTTP {$e->getCode()} thrown for \"GET $nextPageUrl\": {$e->getMessage()}");
                 return [];
             }
             if ($response->getStatusCode() !== 200) {

--- a/src/GitLab/GitLabRepository.php
+++ b/src/GitLab/GitLabRepository.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace T3docs\T3docsTools\GitHub;
+namespace T3docs\T3docsTools\GitLab;
 
 use DateTime;
 use DateTimeImmutable;
 use T3docs\T3docsTools\Configuration;
 
-class GithubRepository
+class GitLabRepository
 {
     /**
      * @var Configuration
@@ -14,7 +14,7 @@ class GithubRepository
     protected $config;
 
     /**
-     * @var GitHubApi
+     * @var GitLabApi
      */
     protected $api;
 
@@ -29,19 +29,19 @@ class GithubRepository
     protected $repos;
 
     /**
-     * @param string $host GitHub host identifier of YAML configuration
-     * @param string $token GitHub API token
+     * @param string $host GitLab host identifier of YAML configuration
+     * @param string $token GitLab API token
      */
     public function __construct(string $host, string $token = '')
     {
         $this->config = Configuration::getInstance();
-        $this->api = new GitHubApi($this->config->getApiUrlOfHost($host), $token);
+        $this->api = new GitLabApi($this->config->getApiUrlOfHost($host), $token);
         $this->host = $host;
     }
 
     /**
-     * @param string $user GitHub user namespace
-     * @param string $type GitHub repository type, docs="TYPO3CMS-*", all="*"
+     * @param string $user GitLab user namespace
+     * @param string $type GitLab repository type, docs="TYPO3CMS-*", all="*"
      */
     public function fetchRepos(string $user = 'typo3-documentation', string $type = 'docs'): void
     {
@@ -50,51 +50,51 @@ class GithubRepository
     }
 
     /**
-     * Retrieve all repositories of GitHub user namespace.
+     * Retrieve all repositories of GitLab user namespace.
      *
-     * @param string $user GitHub user namespace
+     * @param string $user GitLab user namespace
      */
     protected function getRepos(string $user)
     {
-        $this->repos = $this->api->get("users/$user/repos?per_page=100");
+        $this->repos = $this->api->get("groups/$user/projects?per_page=100");
     }
 
     /**
      * Filter out unwanted repos, e.g. ignored, archived, not-included, etc.
      *
-     * @param string $user GitHub user namespace
-     * @param string $type GitHub repository type, docs="TYPO3CMS-*", all="*"
+     * @param string $user GitLab user namespace
+     * @param string $type GitLab repository type, docs="TYPO3CMS-*", all="*"
      */
     protected function filterRepos(string $user, string $type): void
     {
         $repos = [];
 
         foreach ($this->repos as $repo) {
-            if (empty($repo['name'])
-                || $type === 'docs' && strpos($repo['name'], 'TYPO3CMS-') !== 0
+            if (empty($repo['path'])
+                || $type === 'docs' && strpos($repo['path'], 'TYPO3CMS-') !== 0
                 || $repo['archived']
-                || in_array($repo['name'], $this->config->getIgnoredRepos($this->host, $user))
+                || in_array($repo['path'], $this->config->getIgnoredRepos($this->host, $user))
                 || !empty($this->config->getIncludedRepos($this->host, $user))
-                    && !in_array($repo['name'], $this->config->getIncludedRepos($this->host, $user))
+                    && !in_array($repo['path'], $this->config->getIncludedRepos($this->host, $user))
             ){
                 continue;
             }
-            $repos[$repo['name']] = $repo;
+            $repos[$repo['path']] = $repo;
         }
 
         $this->repos = $repos;
     }
 
     /**
-     * Load branch names of GitHub repository via GitHub API.
+     * Load branch names of GitLab repository via GitLab API.
      *
-     * @param string $user GitHub user namespace
-     * @param string $repoName GitHub repository name
-     * @return array Branch names of GitHub repository
+     * @param string $user GitLab user namespace
+     * @param string $repoName GitLab repository name
+     * @return array Branch names of GitLab repository
      */
     public function fetchBranchNamesOfRepo(string $user, string $repoName): array
     {
-        $branches = $this->api->get("repos/$user/$repoName/branches");
+        $branches = $this->api->get("projects/" . urlencode("$user/$repoName") . "/repository/branches");
         $branchNames = [];
 
         foreach ($branches as $branch) {
@@ -105,9 +105,9 @@ class GithubRepository
     }
 
     /**
-     * Load contributors of GitHub repositories via GitHub API.
+     * Load contributors of GitLab repositories via GitLab API.
      *
-     * @param string $repoName GitHub repository name (default=all repositories)
+     * @param string $repoName GitLab repository name (default=all repositories)
      * @param int $year Consider commits of this year (default=current year)
      * @param int $month Consider commits of this month (default=all months)
      * @return array Contributors data
@@ -150,27 +150,16 @@ class GithubRepository
         $names = [];
 
         foreach ($this->repos as $repo) {
-            $names[] = $repo['name'] ?? '';
+            $names[] = $repo['path'] ?? '';
         }
 
         return $names;
     }
 
     /**
-     * Load all commits of GitHub repository via GitHub API.
+     * Load all commits of GitLab repository via GitLab API.
      *
-     * - by default, this returns only 30 commits
-     *   you can change the number of commits with per_page= (max 100)
-     * - you can get further pages with page=
-     *
-     * You MUST use the URLs supplied in the HTTP header link,
-     * example :
-     * Link: <https://api.github.com/repositories/54468502/commits?since=2019-01-01T00%3A00%3A00+01%3A00&until=2019-12-31T23%3A59%3A00+01%3A00&page=2>; rel="next", <https://api.github.com/repositories/54468502/commits?since=2019-01-01T00%3A00%3A00+01%3A00&until=2019-12-31T23%3A59%3A00+01%3A00&page=7>; rel="last"
-     *
-     * see https://developer.github.com/v3/#pagination
-     * https://developer.github.com/v3/guides/traversing-with-pagination/
-     *
-     * @param string $repoName GitHub repository name
+     * @param string $repoName GitLab repository name
      * @param int $year Consider commits of this year (0=current year)
      * @param int $month Consider commits of this month (0=all months)
      * @return array Commits data
@@ -185,10 +174,9 @@ class GithubRepository
             $startDate = new DateTimeImmutable($year . '-01-01 00:00');
             $endDate = new DateTimeImmutable($year . '-12-31 23:59');
         }
-        $commitsUrl = $this->repos[$repoName]['commits_url'];
-        $params = '?since=' . $startDate->format(DateTime::ATOM);
-        $params .= '&until=' . $endDate->format(DateTime::ATOM);
-        $commitsUrl = str_replace('{/sha}', $params, $commitsUrl);
+        $commitsUrl = "projects/" . $this->repos[$repoName]['id'] . "/repository/commits";
+        $commitsUrl .= '?since=' . $startDate->format(DateTime::ATOM);
+        $commitsUrl .= '&until=' . $endDate->format(DateTime::ATOM);
         return $this->api->getAllWithPagination($commitsUrl);
     }
 }

--- a/src/GitLab/GitLabRepository.php
+++ b/src/GitLab/GitLabRepository.php
@@ -128,11 +128,11 @@ class GitLabRepository
             $commits = $this->getCommits($repo, $year, $month);
 
             foreach ($commits as $commit) {
-                $id = $commit['author']['id'];
+                $id = $commit['author_email'] ?? $commit['author_name'];
                 if (!isset($contributors[$id])) {
                     $contributors[$id] = [
-                        'name' => $commit['commit']['author']['name'],
-                        'email' => $commit['commit']['author']['email'],
+                        'name' => $commit['author_name'],
+                        'email' => $commit['author_email'],
                         'count' => 0
                     ];
                 }


### PR DESCRIPTION
Support processing repositories from GitLab besides those of GitHub.

For example, add 
```yaml
hosts:
  gitlab.com:
    type: gitlab
    http_url: "https://gitlab.com/%s/%s"
    ssh_url: "git@gitlab.com:%s/%s.git"
    api_url: "https://gitlab.com/api/v4/"
    repos:
      # Top 10
      coderscare:
        include:
          - gridelements
```
to your /config.local.yml. 

Then run
```
./bash/get-repos.sh all gitlab.com coderscare
```
and process the local repository with
```
./bash/exec-repos.sh "grep -rnIE 'Jo Hasenau' --exclude-dir='.git' ." gitlab.com coderscare
```