### PR TITLE
[BUGFIX] Checkout branches based on "origin" remote

### DIFF
--- a/bash/collect-stats.sh
+++ b/bash/collect-stats.sh
@@ -76,8 +76,7 @@ function collectStats()
                     # Checkout and update current branch
                     exists=$(git branch -a --list "origin/$branch")
                     if [ -n "$exists" ]; then
-                        git checkout -f $branch || exitMsg "checkout $branch in $repo"
-                        git reset --hard origin/$branch || exitMsg "reset --hard origin/$branch in $repo"
+                        git checkout -B $branch origin/$branch || exitMsg "checkout $branch based on origin/$branch in $repo"
                     else
                         continue
                     fi

--- a/bash/exec-repos.sh
+++ b/bash/exec-repos.sh
@@ -84,8 +84,7 @@ function execRepos()
                     # Checkout and update current branch
                     exists=$(git branch -a --list "origin/$branch")
                     if [ -n "$exists" ]; then
-                        git checkout -f $branch || exitMsg "checkout $branch in $repo"
-                        git reset --hard origin/$branch || exitMsg "reset --hard origin/$branch in $repo"
+                        git checkout -B $branch origin/$branch || exitMsg "checkout $branch based on origin/$branch in $repo"
                     else
                         continue
                     fi

--- a/bash/get-repos.sh
+++ b/bash/get-repos.sh
@@ -89,8 +89,7 @@ function getRepos()
                         fi
                     done
                     if [ -n "$mainbranch" ]; then
-                        git checkout -f $mainbranch || exitMsg "checkout $mainbranch in $repo"
-                        git reset --hard origin/$mainbranch || exitMsg "reset --hard origin/$mainbranch in $repo"
+                        git checkout -B $mainbranch origin/$mainbranch || exitMsg "checkout $mainbranch based on origin/$mainbranch in $repo"
                     else
                         echo "The $repo repo is not yet initialized because it lacks a main branch."
                     fi


### PR DESCRIPTION
Explicitly checkout branches based on "origin" remote as there might be defined any other remote target, like e.g. "fork".